### PR TITLE
Do not serialize value of non-scalar FProperty

### DIFF
--- a/Source/VisualStudioTools/Private/VisualStudioToolsCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VisualStudioToolsCommandlet.cpp
@@ -186,6 +186,11 @@ using JsonWriter = TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>;
 
 static bool ShouldSerializePropertyValue(FProperty* Property)
 {
+	if (Property->ArrayDim > 1) // Skip properties that are not scalars
+	{
+		return false;
+	}
+
 	if (FEnumProperty* EnumProperty = CastField<FEnumProperty>(Property))
 	{
 		return true;


### PR DESCRIPTION
If the native class has a property with an array type (e.g., `float[]`), that will pass the current check in
`ShouldSerializePropertyValue` and cause the JSON response to have a format that cannot be parsed in Visual Studio yet.

Skip properties where `ArrayDim > 1`, which means they are not a scalar value.

Note: There are planned changes to the code in VS that is reading the JSON, but having this at the plugin level for now ensures customers can get a solution sooner.

Dev Community ticket: https://developercommunity.visualstudio.com/t/10304107