### PR TITLE
Fix code style violations reported by new VS linter

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,0 +1,91 @@
+[*.{cpp,h}]
+
+# Naming convention rules (note: currently need to be ordered from more to less specific)
+
+cpp_naming_rule.aactor_prefixed.symbols						= aactor_class
+cpp_naming_rule.aactor_prefixed.style						= aactor_style
+
+cpp_naming_rule.swidget_prefixed.symbols					= swidget_class
+cpp_naming_rule.swidget_prefixed.style						= swidget_style
+
+cpp_naming_rule.uobject_prefixed.symbols					= uobject_class
+cpp_naming_rule.uobject_prefixed.style						= uobject_style
+
+cpp_naming_rule.boolelans_prefixed.symbols					= boolelan_vars
+cpp_naming_rule.boolelans_prefixed.style					= boolean_style
+
+cpp_naming_rule.structs_prefixed.symbols					= structs
+cpp_naming_rule.structs_prefixed.style						= unreal_engine_structs
+
+cpp_naming_rule.enums_prefixed.symbols						= enums
+cpp_naming_rule.enums_prefixed.style						= unreal_engine_enums
+
+cpp_naming_rule.templates_prefixed.symbols					= templates
+cpp_naming_rule.templates_prefixed.style					= unreal_engine_templates
+
+cpp_naming_rule.general_names.symbols						= all_symbols
+cpp_naming_rule.general_names.style							= unreal_engine_default
+
+# Naming convention symbols
+
+cpp_naming_symbols.aactor_class.applicable_kinds			= class
+cpp_naming_symbols.aactor_class.applicable_type				= AActor
+
+cpp_naming_symbols.swidget_class.applicable_kinds			= class
+cpp_naming_symbols.swidget_class.applicable_type			= SWidget
+
+cpp_naming_symbols.uobject_class.applicable_kinds			= class
+cpp_naming_symbols.uobject_class.applicable_type			= UObject
+
+cpp_naming_symbols.boolelan_vars.applicable_kinds			= local,parameter,field
+cpp_naming_symbols.boolelan_vars.applicable_type			= bool
+
+cpp_naming_symbols.enums.applicable_kinds					= enum
+
+cpp_naming_symbols.templates.applicable_kinds				= template_class
+
+cpp_naming_symbols.structs.applicable_kinds					= struct
+
+cpp_naming_symbols.all_symbols.applicable_kinds				= *
+
+# Naming convention styles
+
+cpp_naming_style.unreal_engine_default.capitalization		= pascal_case
+cpp_naming_style.unreal_engine_default.required_prefix		=
+cpp_naming_style.unreal_engine_default.required_suffix		=
+cpp_naming_style.unreal_engine_default.word_separator		=
+
+cpp_naming_style.unreal_engine_enums.capitalization			= pascal_case
+cpp_naming_style.unreal_engine_enums.required_prefix		= E
+cpp_naming_style.unreal_engine_enums.required_suffix		=
+cpp_naming_style.unreal_engine_enums.word_separator			=
+
+cpp_naming_style.unreal_engine_templates.capitalization		= pascal_case
+cpp_naming_style.unreal_engine_templates.required_prefix	= T
+cpp_naming_style.unreal_engine_templates.required_suffix	=
+cpp_naming_style.unreal_engine_templates.word_separator		=
+
+cpp_naming_style.unreal_engine_structs.capitalization		= pascal_case
+cpp_naming_style.unreal_engine_structs.required_prefix		= F
+cpp_naming_style.unreal_engine_structs.required_suffix		=
+cpp_naming_style.unreal_engine_structs.word_separator		=
+
+cpp_naming_style.uobject_style.capitalization				= pascal_case
+cpp_naming_style.uobject_style.required_prefix				= U
+cpp_naming_style.uobject_style.required_suffix				=
+cpp_naming_style.uobject_style.word_separator				=
+
+cpp_naming_style.aactor_style.capitalization				= pascal_case
+cpp_naming_style.aactor_style.required_prefix				= A
+cpp_naming_style.aactor_style.required_suffix				=
+cpp_naming_style.aactor_style.word_separator				=
+
+cpp_naming_style.swidget_style.capitalization				= pascal_case
+cpp_naming_style.swidget_style.required_prefix				= S
+cpp_naming_style.swidget_style.required_suffix				=
+cpp_naming_style.swidget_style.word_separator				=
+
+cpp_naming_style.boolean_style.capitalization				= pascal_case
+cpp_naming_style.boolean_style.required_prefix				= b
+cpp_naming_style.boolean_style.required_suffix				=
+cpp_naming_style.boolean_style.word_separator				=

--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -2,90 +2,90 @@
 
 # Naming convention rules (note: currently need to be ordered from more to less specific)
 
-cpp_naming_rule.aactor_prefixed.symbols						= aactor_class
-cpp_naming_rule.aactor_prefixed.style						= aactor_style
+cpp_naming_rule.aactor_prefixed.symbols                    = aactor_class
+cpp_naming_rule.aactor_prefixed.style                      = aactor_style
 
-cpp_naming_rule.swidget_prefixed.symbols					= swidget_class
-cpp_naming_rule.swidget_prefixed.style						= swidget_style
+cpp_naming_rule.swidget_prefixed.symbols                   = swidget_class
+cpp_naming_rule.swidget_prefixed.style                     = swidget_style
 
-cpp_naming_rule.uobject_prefixed.symbols					= uobject_class
-cpp_naming_rule.uobject_prefixed.style						= uobject_style
+cpp_naming_rule.uobject_prefixed.symbols                   = uobject_class
+cpp_naming_rule.uobject_prefixed.style                     = uobject_style
 
-cpp_naming_rule.boolelans_prefixed.symbols					= boolelan_vars
-cpp_naming_rule.boolelans_prefixed.style					= boolean_style
+cpp_naming_rule.boolelans_prefixed.symbols                 = boolelan_vars
+cpp_naming_rule.boolelans_prefixed.style                   = boolean_style
 
-cpp_naming_rule.structs_prefixed.symbols					= structs
-cpp_naming_rule.structs_prefixed.style						= unreal_engine_structs
+cpp_naming_rule.structs_prefixed.symbols                   = structs
+cpp_naming_rule.structs_prefixed.style                     = unreal_engine_structs
 
-cpp_naming_rule.enums_prefixed.symbols						= enums
-cpp_naming_rule.enums_prefixed.style						= unreal_engine_enums
+cpp_naming_rule.enums_prefixed.symbols                     = enums
+cpp_naming_rule.enums_prefixed.style                       = unreal_engine_enums
 
-cpp_naming_rule.templates_prefixed.symbols					= templates
-cpp_naming_rule.templates_prefixed.style					= unreal_engine_templates
+cpp_naming_rule.templates_prefixed.symbols                 = templates
+cpp_naming_rule.templates_prefixed.style                   = unreal_engine_templates
 
-cpp_naming_rule.general_names.symbols						= all_symbols
-cpp_naming_rule.general_names.style							= unreal_engine_default
+cpp_naming_rule.general_names.symbols                      = all_symbols
+cpp_naming_rule.general_names.style                        = unreal_engine_default
 
-# Naming convention symbols
+# Naming convention symbols         
 
-cpp_naming_symbols.aactor_class.applicable_kinds			= class
-cpp_naming_symbols.aactor_class.applicable_type				= AActor
+cpp_naming_symbols.aactor_class.applicable_kinds           = class
+cpp_naming_symbols.aactor_class.applicable_type            = AActor
 
-cpp_naming_symbols.swidget_class.applicable_kinds			= class
-cpp_naming_symbols.swidget_class.applicable_type			= SWidget
+cpp_naming_symbols.swidget_class.applicable_kinds          = class
+cpp_naming_symbols.swidget_class.applicable_type           = SWidget
 
-cpp_naming_symbols.uobject_class.applicable_kinds			= class
-cpp_naming_symbols.uobject_class.applicable_type			= UObject
+cpp_naming_symbols.uobject_class.applicable_kinds          = class
+cpp_naming_symbols.uobject_class.applicable_type           = UObject
 
-cpp_naming_symbols.boolelan_vars.applicable_kinds			= local,parameter,field
-cpp_naming_symbols.boolelan_vars.applicable_type			= bool
+cpp_naming_symbols.boolelan_vars.applicable_kinds          = local,parameter,field
+cpp_naming_symbols.boolelan_vars.applicable_type           = bool
 
-cpp_naming_symbols.enums.applicable_kinds					= enum
+cpp_naming_symbols.enums.applicable_kinds                  = enum
 
-cpp_naming_symbols.templates.applicable_kinds				= template_class
+cpp_naming_symbols.templates.applicable_kinds              = template_class
 
-cpp_naming_symbols.structs.applicable_kinds					= struct
+cpp_naming_symbols.structs.applicable_kinds                = struct
 
-cpp_naming_symbols.all_symbols.applicable_kinds				= *
+cpp_naming_symbols.all_symbols.applicable_kinds            = *
 
 # Naming convention styles
 
-cpp_naming_style.unreal_engine_default.capitalization		= pascal_case
-cpp_naming_style.unreal_engine_default.required_prefix		=
-cpp_naming_style.unreal_engine_default.required_suffix		=
-cpp_naming_style.unreal_engine_default.word_separator		=
+cpp_naming_style.unreal_engine_default.capitalization      = pascal_case
+cpp_naming_style.unreal_engine_default.required_prefix     =
+cpp_naming_style.unreal_engine_default.required_suffix     =
+cpp_naming_style.unreal_engine_default.word_separator      =
 
-cpp_naming_style.unreal_engine_enums.capitalization			= pascal_case
-cpp_naming_style.unreal_engine_enums.required_prefix		= E
-cpp_naming_style.unreal_engine_enums.required_suffix		=
-cpp_naming_style.unreal_engine_enums.word_separator			=
+cpp_naming_style.unreal_engine_enums.capitalization        = pascal_case
+cpp_naming_style.unreal_engine_enums.required_prefix       = E
+cpp_naming_style.unreal_engine_enums.required_suffix       =
+cpp_naming_style.unreal_engine_enums.word_separator        =
 
-cpp_naming_style.unreal_engine_templates.capitalization		= pascal_case
-cpp_naming_style.unreal_engine_templates.required_prefix	= T
-cpp_naming_style.unreal_engine_templates.required_suffix	=
-cpp_naming_style.unreal_engine_templates.word_separator		=
+cpp_naming_style.unreal_engine_templates.capitalization    = pascal_case
+cpp_naming_style.unreal_engine_templates.required_prefix   = T
+cpp_naming_style.unreal_engine_templates.required_suffix   =
+cpp_naming_style.unreal_engine_templates.word_separator    =
 
-cpp_naming_style.unreal_engine_structs.capitalization		= pascal_case
-cpp_naming_style.unreal_engine_structs.required_prefix		= F
-cpp_naming_style.unreal_engine_structs.required_suffix		=
-cpp_naming_style.unreal_engine_structs.word_separator		=
+cpp_naming_style.unreal_engine_structs.capitalization      = pascal_case
+cpp_naming_style.unreal_engine_structs.required_prefix     = F
+cpp_naming_style.unreal_engine_structs.required_suffix     =
+cpp_naming_style.unreal_engine_structs.word_separator      =
 
-cpp_naming_style.uobject_style.capitalization				= pascal_case
-cpp_naming_style.uobject_style.required_prefix				= U
-cpp_naming_style.uobject_style.required_suffix				=
-cpp_naming_style.uobject_style.word_separator				=
+cpp_naming_style.uobject_style.capitalization              = pascal_case
+cpp_naming_style.uobject_style.required_prefix             = U
+cpp_naming_style.uobject_style.required_suffix             =
+cpp_naming_style.uobject_style.word_separator              =
 
-cpp_naming_style.aactor_style.capitalization				= pascal_case
-cpp_naming_style.aactor_style.required_prefix				= A
-cpp_naming_style.aactor_style.required_suffix				=
-cpp_naming_style.aactor_style.word_separator				=
+cpp_naming_style.aactor_style.capitalization               = pascal_case
+cpp_naming_style.aactor_style.required_prefix              = A
+cpp_naming_style.aactor_style.required_suffix              =
+cpp_naming_style.aactor_style.word_separator               =
 
-cpp_naming_style.swidget_style.capitalization				= pascal_case
-cpp_naming_style.swidget_style.required_prefix				= S
-cpp_naming_style.swidget_style.required_suffix				=
-cpp_naming_style.swidget_style.word_separator				=
+cpp_naming_style.swidget_style.capitalization              = pascal_case
+cpp_naming_style.swidget_style.required_prefix             = S
+cpp_naming_style.swidget_style.required_suffix             =
+cpp_naming_style.swidget_style.word_separator              =
 
-cpp_naming_style.boolean_style.capitalization				= pascal_case
-cpp_naming_style.boolean_style.required_prefix				= b
-cpp_naming_style.boolean_style.required_suffix				=
-cpp_naming_style.boolean_style.word_separator				=
+cpp_naming_style.boolean_style.capitalization              = pascal_case
+cpp_naming_style.boolean_style.required_prefix             = b
+cpp_naming_style.boolean_style.required_suffix             =
+cpp_naming_style.boolean_style.word_separator              =


### PR DESCRIPTION
Renamed variables, types and namespace to better match the UE naming style.
Added `.editorconfig` to enforce checks using the new VS feature in preview.