### PR TITLE
Add TAfUE functionality to plugin as UVSTestAdapterCommandlet class

### DIFF
--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -52,7 +52,7 @@ int32 UVSTestAdapterCommandlet::ListTests( const FString& TargetFile )
 		const FString SourceFile = TestInfo.GetSourceFile();
 		const int32 Line = TestInfo.GetSourceFileLine();
 
-		OutFile << *TestCommand << TEXT( "," ) << *DisplayName << TEXT( "," ) << Line << TEXT( "," ) << *SourceFile << std::endl;
+		OutFile << *TestCommand << TEXT( "|" ) << *DisplayName << TEXT( "|" ) << Line << TEXT( "|" ) << *SourceFile << std::endl;
 	}
 
 	UE_LOG( LogVisualStudioTools, Display, TEXT( "Found %d tests" ), TestInfos.Num() );
@@ -111,12 +111,12 @@ int32 UVSTestAdapterCommandlet::RunTests( const FString& TestListFile, const FSt
 		}
 
 		FAutomationTestExecutionInfo ExecutionInfo;
-		const bool CurrentTestSuccessful = Framework.StopTest( ExecutionInfo );
+		const bool CurrentTestSuccessful = Framework.StopTest( ExecutionInfo ) && ExecutionInfo.GetErrorTotal() == 0;
 		AllSuccessful = AllSuccessful && CurrentTestSuccessful;
 
 		const FString Result = CurrentTestSuccessful ? TEXT( "OK" ) : TEXT( "FAIL" );
 
-		OutFile << TEXT( "[RUNTEST]" ) << *TestCommand << TEXT( "," ) << *DisplayName << TEXT( "," ) << *Result << TEXT( "," ) << ExecutionInfo.Duration << std::endl;
+		OutFile << TEXT( "[RUNTEST]" ) << *TestCommand << TEXT( "|" ) << *DisplayName << TEXT( "|" ) << *Result << TEXT( "|" ) << ExecutionInfo.Duration << std::endl;
 
 		if ( !CurrentTestSuccessful )
 		{
@@ -124,7 +124,7 @@ int32 UVSTestAdapterCommandlet::RunTests( const FString& TestListFile, const FSt
 			{
 				if ( Entry.Event.Type == EAutomationEventType::Error )
 				{
-					OutFile << **Entry.Event.Message << std::endl;
+					OutFile << *Entry.Event.Message << std::endl;
 					UE_LOG( LogVisualStudioTools, Error, TEXT( "%s" ), *Entry.Event.Message );
 				}
 			}

--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -1,0 +1,177 @@
+// Copyright 2022 (c) Microsoft. All rights reserved.
+
+#include "VSTestAdapterCommandlet.h"
+
+#include <Runtime/Core/Public/Async/TaskGraphInterfaces.h>
+#include <Runtime/Core/Public/Containers/Ticker.h>
+#include <fstream>
+#include <string>
+
+#include "VisualStudioTools.h"
+
+int32 UVSTestAdapterCommandlet::Main(const FString& Params)
+{
+	TArray<FString> Tokens;
+	TArray<FString> Switches;
+	TMap<FString, FString> ParamVals;
+
+	// Functionality for Unreal Engine Test Adapter.
+	ParseCommandLine(*Params, Tokens, Switches, ParamVals);
+	FAutomationTestFramework::GetInstance().SetRequestedTestFilter( EAutomationTestFlags::PriorityMask | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::SmokeFilter | EAutomationTestFlags::PerfFilter | EAutomationTestFlags::StressFilter | EAutomationTestFlags::NegativeFilter );	
+	if ( ParamVals.Contains( TEXT( "listtests" ) ) )
+	{
+		return ListTests( ParamVals[TEXT( "listtests" )] );
+	}
+	else if ( ParamVals.Contains( TEXT( "runtests" ) ) && ParamVals.Contains( TEXT( "testresultfile" ) ) )
+	{
+		return RunTests( ParamVals[TEXT( "runtests" )], ParamVals[TEXT( "testresultfile" )] );
+	}
+
+	return 0;
+}
+
+
+int32 UVSTestAdapterCommandlet::ListTests( const FString& TargetFile )
+{
+	std::wofstream OutFile( *TargetFile );
+	if ( !OutFile.good() )
+	{
+		UE_LOG( LogVisualStudioTools, Error, TEXT( "Failed to open file at path: %s" ), *TargetFile );
+		return 1;
+	}
+
+	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
+
+	TArray< FAutomationTestInfo > TestInfos;
+	GetAllTests( TestInfos );
+
+	for ( const auto& TestInfo : TestInfos )
+	{
+		const FString TestCommand = TestInfo.GetTestName();
+		const FString DisplayName = TestInfo.GetDisplayName();
+		const FString SourceFile = TestInfo.GetSourceFile();
+		const int32 Line = TestInfo.GetSourceFileLine();
+
+		OutFile << *TestCommand << TEXT( "," ) << *DisplayName << TEXT( "," ) << Line << TEXT( "," ) << *SourceFile << std::endl;
+	}
+
+	UE_LOG( LogVisualStudioTools, Display, TEXT( "Found %d tests" ), TestInfos.Num() );
+
+	OutFile.close();
+	return 0;
+}
+
+int32 UVSTestAdapterCommandlet::RunTests( const FString& TestListFile, const FString& ResultsFile )
+{
+	std::wofstream OutFile( *ResultsFile );
+	if ( !OutFile.good() )
+	{
+		UE_LOG( LogVisualStudioTools, Error, TEXT( "Failed to open file at path: %s" ), *ResultsFile );
+		return 1;
+	}
+
+	TArray< FAutomationTestInfo > TestInfos;
+	if ( TestListFile.Equals( TEXT( "All" ), ESearchCase::IgnoreCase ) )
+	{
+		GetAllTests( TestInfos );
+	}
+	else
+	{
+		ReadTestsFromFile( TestListFile, TestInfos );
+	}
+
+	bool AllSuccessful = true;
+
+	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
+
+	for ( const FAutomationTestInfo& TestInfo : TestInfos )
+	{
+		const FString TestCommand = TestInfo.GetTestName();
+		const FString DisplayName = TestInfo.GetDisplayName();
+
+		UE_LOG( LogVisualStudioTools, Log, TEXT( "Running %s" ), *DisplayName );
+
+		const int32 RoleIndex = 0; // always default to "local" role index.  Only used for multi-participant tests
+		Framework.StartTestByName( TestCommand, RoleIndex );
+
+		FDateTime Last = FDateTime::UtcNow();
+
+		while ( !Framework.ExecuteLatentCommands() )
+		{
+			// Because we are not 'ticked' by the Engine we need to pump the TaskGraph
+			FTaskGraphInterface::Get().ProcessThreadUntilIdle( ENamedThreads::GameThread );
+
+			const FDateTime Now = FDateTime::UtcNow();
+			const FTimespan Delta = Now - Last;
+
+			// .. and the core FTicker
+			FTSTicker::GetCoreTicker().Tick( Delta.GetTotalSeconds() );
+
+			Last = Now;
+		}
+
+		FAutomationTestExecutionInfo ExecutionInfo;
+		const bool CurrentTestSuccessful = Framework.StopTest( ExecutionInfo );
+		AllSuccessful = AllSuccessful && CurrentTestSuccessful;
+
+		const FString Result = CurrentTestSuccessful ? TEXT( "OK" ) : TEXT( "FAIL" );
+
+		OutFile << TEXT( "[RUNTEST]" ) << *TestCommand << TEXT( "," ) << *DisplayName << TEXT( "," ) << *Result << TEXT( "," ) << ExecutionInfo.Duration << std::endl;
+
+		if ( !CurrentTestSuccessful )
+		{
+			for ( const auto& Entry : ExecutionInfo.GetEntries() )
+			{
+				if ( Entry.Event.Type == EAutomationEventType::Error )
+				{
+					OutFile << **Entry.Event.Message << std::endl;
+					UE_LOG( LogVisualStudioTools, Error, TEXT( "%s" ), *Entry.Event.Message );
+				}
+			}
+
+			UE_LOG( LogVisualStudioTools, Log, TEXT( "Failed  %s" ), *DisplayName );
+		}
+
+		OutFile.flush();
+	}
+
+	return AllSuccessful ? 0 : 1;
+}
+
+
+void UVSTestAdapterCommandlet::ReadTestsFromFile( const FString& InFile, TArray< FAutomationTestInfo >& OutTestList )
+{
+	TSet< FString > TestCommands;
+
+	std::wifstream InStream( *InFile );
+	if ( !InStream.good() )
+	{
+		UE_LOG( LogVisualStudioTools, Error, TEXT( "Failed to open file at path: %s" ), *InFile );
+		return;
+	}
+
+	std::wstring Line;
+	while ( std::getline( InStream, Line ) )
+	{
+		if ( Line.length() > 0 )
+		{
+			TestCommands.Add( FString( Line.c_str() ) );
+		}
+	}
+	InStream.close();
+
+	GetAllTests( OutTestList );
+	for ( int32 Idx = OutTestList.Num() - 1; Idx >= 0; Idx-- )
+	{
+		if ( !TestCommands.Contains( OutTestList[Idx].GetTestName() ) )
+		{
+			OutTestList.RemoveAt( Idx );
+		}
+	}
+}
+
+void UVSTestAdapterCommandlet::GetAllTests( TArray< FAutomationTestInfo >& OutTestList )
+{
+	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
+	Framework.GetValidTestNames( OutTestList );
+}

--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -2,12 +2,45 @@
 
 #include "VSTestAdapterCommandlet.h"
 
-#include <Runtime/Core/Public/Async/TaskGraphInterfaces.h>
-#include <Runtime/Core/Public/Containers/Ticker.h>
-#include <fstream>
+#include "Runtime/Core/Public/Async/TaskGraphInterfaces.h"
+#include "Runtime/Core/Public/Containers/Ticker.h"
 #include <string>
 
 #include "VisualStudioTools.h"
+
+static constexpr auto ListTestsParam = TEXT("listtests");
+static constexpr auto RunTestsParam = TEXT("runtests");
+static constexpr auto TestResultsFileParam = TEXT("testresultfile");
+static constexpr auto HelpParam = TEXT("help");
+
+UVSTestAdapterCommandlet::UVSTestAdapterCommandlet()
+{
+	HelpDescription = TEXT("Commandlet for generating data used by Blueprint support in Visual Studio.");
+	HelpUsage = TEXT("<Editor-Cmd.exe> <path_to_uproject> -run=VSTestAdapter [-stdout -multiprocess -silent -unattended -AllowStdOutLogVerbosity -NoShaderCompile]");
+
+	HelpParamNames.Add(ListTestsParam);
+	HelpParamDescriptions.Add(TEXT("[Optional] The file path to write the test cases retrieved from FAutomationTestFramework"));
+
+	HelpParamNames.Add(RunTestsParam);
+	HelpParamDescriptions.Add(TEXT("[Optional] The test cases that will be sent to FAutomationTestFramework to run."));
+
+	HelpParamNames.Add(TestResultsFileParam);
+	HelpParamDescriptions.Add(TEXT("[Optional] The output file from running test cases that we parse to retrieve test case results."));
+
+	HelpParamNames.Add(HelpParam);
+	HelpParamDescriptions.Add(TEXT("[Optional] Print this help message and quit the commandlet immediately."));
+}
+
+void UVSTestAdapterCommandlet::PrintHelp() const
+{
+	UE_LOG(LogVisualStudioTools, Display, TEXT("%s"), *HelpDescription);
+	UE_LOG(LogVisualStudioTools, Display, TEXT("Usage: %s"), *HelpUsage);
+	UE_LOG(LogVisualStudioTools, Display, TEXT("Parameters:"));
+	for (int32 Idx = 0; Idx < HelpParamNames.Num(); ++Idx)
+	{
+		UE_LOG(LogVisualStudioTools, Display, TEXT("\t-%s: %s"), *HelpParamNames[Idx], *HelpParamDescriptions[Idx]);
+	}
+}
 
 int32 UVSTestAdapterCommandlet::Main(const FString& Params)
 {
@@ -17,119 +50,128 @@ int32 UVSTestAdapterCommandlet::Main(const FString& Params)
 
 	// Functionality for Unreal Engine Test Adapter.
 	ParseCommandLine(*Params, Tokens, Switches, ParamVals);
-	FAutomationTestFramework::GetInstance().SetRequestedTestFilter( EAutomationTestFlags::PriorityMask | EAutomationTestFlags::ProductFilter | EAutomationTestFlags::SmokeFilter | EAutomationTestFlags::PerfFilter | EAutomationTestFlags::StressFilter | EAutomationTestFlags::NegativeFilter );	
-	if ( ParamVals.Contains( TEXT( "listtests" ) ) )
+	if (ParamVals.Contains(HelpParam))
 	{
-		return ListTests( ParamVals[TEXT( "listtests" )] );
+		PrintHelp();
+		return 0;
 	}
-	else if ( ParamVals.Contains( TEXT( "runtests" ) ) && ParamVals.Contains( TEXT( "testresultfile" ) ) )
+
+	FAutomationTestFramework::GetInstance().SetRequestedTestFilter(EAutomationTestFlags::PriorityMask |
+		EAutomationTestFlags::ProductFilter | EAutomationTestFlags::SmokeFilter |
+		EAutomationTestFlags::PerfFilter |
+		EAutomationTestFlags::StressFilter | EAutomationTestFlags::NegativeFilter);
+	if (ParamVals.Contains(ListTestsParam))
 	{
-		return RunTests( ParamVals[TEXT( "runtests" )], ParamVals[TEXT( "testresultfile" )] );
+		return ListTests(ParamVals[ListTestsParam]);
+	}
+	else if (ParamVals.Contains(RunTestsParam) && ParamVals.Contains(TestResultsFileParam))
+	{
+		return RunTests(ParamVals[RunTestsParam], ParamVals[TestResultsFileParam]);
 	}
 
 	return 0;
 }
 
 
-int32 UVSTestAdapterCommandlet::ListTests( const FString& TargetFile )
+int32 UVSTestAdapterCommandlet::ListTests(const FString& TargetFile)
 {
-	std::wofstream OutFile( *TargetFile );
-	if ( !OutFile.good() )
+	std::wofstream OutFile(*TargetFile);
+	if (!OutFile.good())
 	{
-		UE_LOG( LogVisualStudioTools, Error, TEXT( "Failed to open file at path: %s" ), *TargetFile );
+		UE_LOG(LogVisualStudioTools, Error, TEXT("Failed to open file at path: %s"), *TargetFile);
 		return 1;
 	}
 
 	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
 
 	TArray< FAutomationTestInfo > TestInfos;
-	GetAllTests( TestInfos );
+	GetAllTests(TestInfos);
 
-	for ( const auto& TestInfo : TestInfos )
+	for (const auto& TestInfo : TestInfos)
 	{
 		const FString TestCommand = TestInfo.GetTestName();
 		const FString DisplayName = TestInfo.GetDisplayName();
 		const FString SourceFile = TestInfo.GetSourceFile();
 		const int32 Line = TestInfo.GetSourceFileLine();
 
-		OutFile << *TestCommand << TEXT( "|" ) << *DisplayName << TEXT( "|" ) << Line << TEXT( "|" ) << *SourceFile << std::endl;
+		OutFile << *TestCommand << TEXT("|") << *DisplayName << TEXT("|") << Line << TEXT("|") << *SourceFile << std::endl;
 	}
 
-	UE_LOG( LogVisualStudioTools, Display, TEXT( "Found %d tests" ), TestInfos.Num() );
+	UE_LOG(LogVisualStudioTools, Display, TEXT("Found %d tests"), TestInfos.Num());
 
 	OutFile.close();
 	return 0;
 }
 
-int32 UVSTestAdapterCommandlet::RunTests( const FString& TestListFile, const FString& ResultsFile )
+int32 UVSTestAdapterCommandlet::RunTests(const FString& TestListFile, const FString& ResultsFile)
 {
-	std::wofstream OutFile( *ResultsFile );
-	if ( !OutFile.good() )
+	std::wofstream OutFile(*ResultsFile);
+	if (!OutFile.good())
 	{
-		UE_LOG( LogVisualStudioTools, Error, TEXT( "Failed to open file at path: %s" ), *ResultsFile );
+		UE_LOG(LogVisualStudioTools, Error, TEXT("Failed to open file at path: %s"), *ResultsFile);
 		return 1;
 	}
 
 	TArray< FAutomationTestInfo > TestInfos;
-	if ( TestListFile.Equals( TEXT( "All" ), ESearchCase::IgnoreCase ) )
+	if (TestListFile.Equals(TEXT("All"), ESearchCase::IgnoreCase))
 	{
-		GetAllTests( TestInfos );
+		GetAllTests(TestInfos);
 	}
 	else
 	{
-		ReadTestsFromFile( TestListFile, TestInfos );
+		ReadTestsFromFile(TestListFile, TestInfos);
 	}
 
 	bool AllSuccessful = true;
 
 	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
 
-	for ( const FAutomationTestInfo& TestInfo : TestInfos )
+	for (const FAutomationTestInfo& TestInfo : TestInfos)
 	{
 		const FString TestCommand = TestInfo.GetTestName();
 		const FString DisplayName = TestInfo.GetDisplayName();
 
-		UE_LOG( LogVisualStudioTools, Log, TEXT( "Running %s" ), *DisplayName );
+		UE_LOG(LogVisualStudioTools, Log, TEXT("Running %s"), *DisplayName);
 
 		const int32 RoleIndex = 0; // always default to "local" role index.  Only used for multi-participant tests
-		Framework.StartTestByName( TestCommand, RoleIndex );
+		Framework.StartTestByName(TestCommand, RoleIndex);
 
 		FDateTime Last = FDateTime::UtcNow();
 
-		while ( !Framework.ExecuteLatentCommands() )
+		while (!Framework.ExecuteLatentCommands())
 		{
 			// Because we are not 'ticked' by the Engine we need to pump the TaskGraph
-			FTaskGraphInterface::Get().ProcessThreadUntilIdle( ENamedThreads::GameThread );
+			FTaskGraphInterface::Get().ProcessThreadUntilIdle(ENamedThreads::GameThread);
 
 			const FDateTime Now = FDateTime::UtcNow();
 			const FTimespan Delta = Now - Last;
 
 			// .. and the core FTicker
-			FTSTicker::GetCoreTicker().Tick( Delta.GetTotalSeconds() );
+			FTSTicker::GetCoreTicker().Tick(Delta.GetTotalSeconds());
 
 			Last = Now;
 		}
 
 		FAutomationTestExecutionInfo ExecutionInfo;
-		const bool CurrentTestSuccessful = Framework.StopTest( ExecutionInfo ) && ExecutionInfo.GetErrorTotal() == 0;
+		const bool CurrentTestSuccessful = Framework.StopTest(ExecutionInfo) && ExecutionInfo.GetErrorTotal() == 0;
 		AllSuccessful = AllSuccessful && CurrentTestSuccessful;
 
-		const FString Result = CurrentTestSuccessful ? TEXT( "OK" ) : TEXT( "FAIL" );
+		const FString Result = CurrentTestSuccessful ? TEXT("OK") : TEXT("FAIL");
 
-		OutFile << TEXT( "[RUNTEST]" ) << *TestCommand << TEXT( "|" ) << *DisplayName << TEXT( "|" ) << *Result << TEXT( "|" ) << ExecutionInfo.Duration << std::endl;
+		OutFile << TEXT("[RUNTEST]") << *TestCommand << TEXT("|") << *DisplayName << TEXT("|") << *Result << TEXT("|") << ExecutionInfo.Duration << std::endl;
 
-		if ( !CurrentTestSuccessful )
+		if (!CurrentTestSuccessful)
 		{
-			for ( const auto& Entry : ExecutionInfo.GetEntries() )
+			for (const auto& Entry : ExecutionInfo.GetEntries())
 			{
-				if ( Entry.Event.Type == EAutomationEventType::Error )
+				if (Entry.Event.Type == EAutomationEventType::Error)
 				{
 					OutFile << *Entry.Event.Message << std::endl;
-					UE_LOG( LogVisualStudioTools, Error, TEXT( "%s" ), *Entry.Event.Message );
+					UE_LOG(LogVisualStudioTools, Error, TEXT("%s"), *Entry.Event.Message);
 				}
 			}
 
-			UE_LOG( LogVisualStudioTools, Log, TEXT( "Failed  %s" ), *DisplayName );
+			UE_LOG(LogVisualStudioTools, Log, TEXT("Failed  %s"), *DisplayName);
 		}
 
 		OutFile.flush();
@@ -139,39 +181,39 @@ int32 UVSTestAdapterCommandlet::RunTests( const FString& TestListFile, const FSt
 }
 
 
-void UVSTestAdapterCommandlet::ReadTestsFromFile( const FString& InFile, TArray< FAutomationTestInfo >& OutTestList )
+void UVSTestAdapterCommandlet::ReadTestsFromFile(const FString& InFile, TArray< FAutomationTestInfo >& OutTestList)
 {
 	TSet< FString > TestCommands;
 
-	std::wifstream InStream( *InFile );
-	if ( !InStream.good() )
+	std::wifstream InStream(*InFile);
+	if (!InStream.good())
 	{
-		UE_LOG( LogVisualStudioTools, Error, TEXT( "Failed to open file at path: %s" ), *InFile );
+		UE_LOG(LogVisualStudioTools, Error, TEXT("Failed to open file at path: %s"), *InFile);
 		return;
 	}
 
 	std::wstring Line;
-	while ( std::getline( InStream, Line ) )
+	while (std::getline(InStream, Line))
 	{
-		if ( Line.length() > 0 )
+		if (Line.length() > 0)
 		{
-			TestCommands.Add( FString( Line.c_str() ) );
+			TestCommands.Add(FString(Line.c_str()));
 		}
 	}
 	InStream.close();
 
-	GetAllTests( OutTestList );
-	for ( int32 Idx = OutTestList.Num() - 1; Idx >= 0; Idx-- )
+	GetAllTests(OutTestList);
+	for (int32 Idx = OutTestList.Num() - 1; Idx >= 0; Idx--)
 	{
-		if ( !TestCommands.Contains( OutTestList[Idx].GetTestName() ) )
+		if (!TestCommands.Contains(OutTestList[Idx].GetTestName()))
 		{
-			OutTestList.RemoveAt( Idx );
+			OutTestList.RemoveAt(Idx);
 		}
 	}
 }
 
-void UVSTestAdapterCommandlet::GetAllTests( TArray< FAutomationTestInfo >& OutTestList )
+void UVSTestAdapterCommandlet::GetAllTests(TArray< FAutomationTestInfo >& OutTestList)
 {
 	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
-	Framework.GetValidTestNames( OutTestList );
+	Framework.GetValidTestNames(OutTestList);
 }

--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.h
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.h
@@ -1,0 +1,28 @@
+// Copyright 2022 (c) Microsoft. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Commandlets/Commandlet.h"
+
+#include <Runtime/Core/Public/Misc/AutomationTest.h>
+#include <Runtime/CoreUObject/Public/UObject/ObjectMacros.h>
+#include <Runtime/Engine/Classes/Commandlets/Commandlet.h>
+
+#include "VSTestAdapterCommandlet.generated.h"
+
+UCLASS()
+class UVSTestAdapterCommandlet
+	: public UCommandlet
+{
+	GENERATED_BODY()
+
+public:
+	virtual int32 Main(const FString& Params) override;
+	int32 RunTests( const FString& TestListFile, const FString& ResultsFile );
+	int32 ListTests( const FString& TargetFile );
+
+private:
+	void ReadTestsFromFile( const FString& InFile, TArray<FAutomationTestInfo>& OutTestList );
+	void GetAllTests( TArray<FAutomationTestInfo>& OutTestList );
+};

--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.h
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.h
@@ -22,11 +22,7 @@ public:
 
 public:
 	virtual int32 Main(const FString& Params) override;
-	int32 RunTests(const FString& TestListFile, const FString& ResultsFile);
-	int32 ListTests(const FString& TargetFile);
 
 private:
-	void ReadTestsFromFile(const FString& InFile, TArray<FAutomationTestInfo>& OutTestList);
-	void GetAllTests(TArray<FAutomationTestInfo>& OutTestList);
 	void PrintHelp() const;
 };

--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.h
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.h
@@ -18,11 +18,15 @@ class UVSTestAdapterCommandlet
 	GENERATED_BODY()
 
 public:
+	UVSTestAdapterCommandlet();
+
+public:
 	virtual int32 Main(const FString& Params) override;
-	int32 RunTests( const FString& TestListFile, const FString& ResultsFile );
-	int32 ListTests( const FString& TargetFile );
+	int32 RunTests(const FString& TestListFile, const FString& ResultsFile);
+	int32 ListTests(const FString& TargetFile);
 
 private:
-	void ReadTestsFromFile( const FString& InFile, TArray<FAutomationTestInfo>& OutTestList );
-	void GetAllTests( TArray<FAutomationTestInfo>& OutTestList );
+	void ReadTestsFromFile(const FString& InFile, TArray<FAutomationTestInfo>& OutTestList);
+	void GetAllTests(TArray<FAutomationTestInfo>& OutTestList);
+	void PrintHelp() const;
 };


### PR DESCRIPTION
Registering a new commandlet class in the plugin allows for more flexibility in the future and reduces maintanence costs.