### PR TITLE
Introduce commandlet for blueprint search

### DIFF
--- a/Source/VisualStudioTools/Private/BlueprintAssetHelper.cpp
+++ b/Source/VisualStudioTools/Private/BlueprintAssetHelper.cpp
@@ -1,0 +1,109 @@
+// Copyright 2022 (c) Microsoft. All rights reserved.
+// Licensed under the MIT License.
+
+#include "BlueprintAssetHelpers.h"
+
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Engine/BlueprintGeneratedClass.h"
+#include "Engine/StreamableManager.h"
+#include "Misc/ScopeExit.h"
+#include "VisualStudioTools.h"
+
+namespace VisualStudioTools
+{
+namespace AssetHelpers
+{
+/*
+* These helpers handle the usage of some APIs that were deprecated in 5.1
+* but the replacements are not available in older versions.
+* Might be overridden by the `Build.cs` rules
+*/
+#if FILTER_ASSETS_BY_CLASS_PATH
+
+void SetBlueprintClassFilter(FARFilter& InOutFilter)
+{
+	// UE5.1 deprecated the API to filter using class names
+	InOutFilter.ClassPaths.Add(UBlueprintCore::StaticClass()->GetClassPathName());
+}
+
+static FString GetObjectPathString(const FAssetData& InAssetData)
+{
+	// UE5.1 deprecated 'FAssetData::ObjectPath' in favor of 'FAssetData::GetObjectPathString()'
+	return InAssetData.GetObjectPathString();
+}
+
+#else // FILTER_ASSETS_BY_CLASS_PATH
+
+void SetBlueprintClassFilter(FARFilter& InOutFilter)
+{
+	InOutFilter.ClassNames.Add(UBlueprintCore::StaticClass()->GetFName());
+}
+
+static FString GetObjectPathString(const FAssetData& InAssetData)
+{
+	return InAssetData.ObjectPath.ToString();
+}
+
+#endif // FILTER_ASSETS_BY_CLASS_PATH
+
+void ForEachAsset(
+	const TArray<FAssetData>& TargetAssets,
+	TFunctionRef<void(UBlueprintGeneratedClass*, const FAssetData& AssetData)> Callback)
+{
+	// Show a simpler logging output.
+	// LogTimes are still useful to tell how long it takes to process each asset.
+	TGuardValue<bool> DisableLogVerbosity(GPrintLogVerbosity, false);
+	TGuardValue<bool> DisableLogCategory(GPrintLogCategory, false);
+
+	// We're about to load the assets which might trigger a ton of log messages
+	// Temporarily suppress them during this stage.
+	GEngine->Exec(nullptr, TEXT("log LogVisualStudioTools only"));
+	ON_SCOPE_EXIT
+	{
+		GEngine->Exec(nullptr, TEXT("log reset"));
+	};
+
+	FStreamableManager AssetLoader;
+
+	for (int32 Idx = 0; Idx < TargetAssets.Num(); Idx++)
+	{
+		const FAssetData AssetData = TargetAssets[Idx];
+		FSoftClassPath GenClassPath = AssetData.GetTagValueRef<FString>(FBlueprintTags::GeneratedClassPath);
+		UE_LOG(LogVisualStudioTools, Display, TEXT("Processing blueprints [%d/%d]: %s"), Idx + 1, TargetAssets.Num(), *GenClassPath.ToString());
+
+		TSharedPtr<FStreamableHandle> Handle = AssetLoader.RequestSyncLoad(GenClassPath);
+		ON_SCOPE_EXIT
+		{
+			// We're done, notify an unload.
+			Handle->ReleaseHandle();
+		};
+
+		if (!Handle.IsValid())
+		{
+			continue;
+		}
+
+		if (auto BlueprintGeneratedClass = Cast<UBlueprintGeneratedClass>(Handle->GetLoadedAsset()))
+		{
+			Callback(BlueprintGeneratedClass, AssetData);
+		}
+		else
+		{
+			// Log some extra information to help the user understand why the asset failed to load.
+
+			FString ObjectPathString = AssetHelpers::GetObjectPathString(AssetData);
+
+			FString Msg = !GenClassPath.ToString().Contains(ObjectPathString)
+				? FString::Printf(
+					TEXT("ObjectPath is not compatible with GenClassPath, consider re-saving it to avoid future issues. { ObjectPath: %s, GenClassPath: %s }"),
+					*ObjectPathString,
+					*GenClassPath.ToString())
+				: FString::Printf(TEXT("ClassPath: %s"), *GenClassPath.ToString());
+
+			UE_LOG(LogVisualStudioTools, Warning, TEXT("Failed to load Blueprint. Skipping. %s"), *Msg);
+		}
+	}
+}
+
+}
+}

--- a/Source/VisualStudioTools/Private/BlueprintAssetHelper.cpp
+++ b/Source/VisualStudioTools/Private/BlueprintAssetHelper.cpp
@@ -80,6 +80,7 @@ void ForEachAsset(
 
 		if (!Handle.IsValid())
 		{
+			UE_LOG(LogVisualStudioTools, Warning, TEXT("Failed to get a streamable handle for Blueprint. Skipping. GenClassPath: %s"), *GenClassPath.ToString());
 			continue;
 		}
 

--- a/Source/VisualStudioTools/Private/BlueprintAssetHelpers.h
+++ b/Source/VisualStudioTools/Private/BlueprintAssetHelpers.h
@@ -1,0 +1,18 @@
+// Copyright 2022 (c) Microsoft. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "CoreMinimal.h"
+
+namespace VisualStudioTools 
+{
+namespace AssetHelpers
+{
+void SetBlueprintClassFilter(FARFilter& InOutFilter);
+
+void ForEachAsset(
+	const TArray<FAssetData>& TargetAssets,
+	TFunctionRef<void(UBlueprintGeneratedClass*, const FAssetData& AssetData)> Callback);
+
+} // namespace AssetHelpers
+} // namespace VisualStudioTools

--- a/Source/VisualStudioTools/Private/BlueprintAssetHelpers.h
+++ b/Source/VisualStudioTools/Private/BlueprintAssetHelpers.h
@@ -10,6 +10,11 @@ namespace AssetHelpers
 {
 void SetBlueprintClassFilter(FARFilter& InOutFilter);
 
+/**
+* Loads each blueprint asset and invokes the callback with the resulting blueprint generated class.
+* Each iteration will load the asset using a FStreamableHandle and verify that is a valid blueprint
+* before invoking the callback.
+*/
 void ForEachAsset(
 	const TArray<FAssetData>& TargetAssets,
 	TFunctionRef<void(UBlueprintGeneratedClass*, const FAssetData& AssetData)> Callback);

--- a/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.cpp
@@ -1,0 +1,220 @@
+// Copyright 2022 (c) Microsoft. All rights reserved.
+// Licensed under the MIT License.
+
+#include "BlueprintReferencesCommandlet.h"
+
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "BlueprintAssetHelpers.h"
+#include "Engine/BlueprintGeneratedClass.h"
+#include "FindInBlueprintManager.h"
+#include "JsonObjectConverter.h"
+#include "Misc/ScopeExit.h"
+#include "Policies/CondensedJsonPrintPolicy.h"
+#include "VisualStudioTools.h"
+
+namespace VisualStudioTools
+{
+static FString StripClassPrefix(const FString&& InClassName)
+{
+	if (InClassName.IsEmpty())
+	{
+		return InClassName;
+	}
+
+	size_t PrefixSize = 0;
+
+	const TCHAR ClassPrefixChar = InClassName[0];
+	switch (ClassPrefixChar)
+	{
+	case TEXT('I'):
+	case TEXT('A'):
+	case TEXT('U'):
+		// If it is a class prefix, check for deprecated class prefix also
+		if (InClassName.Len() > 12 && FCString::Strncmp(&(InClassName[1]), TEXT("DEPRECATED_"), 11) == 0)
+		{
+			PrefixSize = 12;
+		}
+		else
+		{
+			PrefixSize = 1;
+		}
+		break;
+	case TEXT('F'):
+	case TEXT('T'):
+		// Struct prefixes are also fine.
+		PrefixSize = 1;
+		break;
+	default:
+		PrefixSize = 0;
+		break;
+	}
+
+	return InClassName.RightChop(PrefixSize);
+}
+
+TArray<FAssetData> GetMatchingAssetsForSearchQuery(const FString& SearchValue)
+{
+	TArray<FSearchResult> OutItemsFound;
+	FStreamSearch StreamSearch(SearchValue);
+	while (!StreamSearch.IsComplete())
+	{
+		FFindInBlueprintSearchManager::Get().Tick(0.0);
+	}
+
+	StreamSearch.GetFilteredItems(OutItemsFound);
+
+	IAssetRegistry& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry")).Get();
+
+	TArray<FAssetData> OutTargetAssets;
+	Algo::Transform(OutItemsFound, OutTargetAssets,
+		[&](const FSearchResult& Item)
+		{
+#if FILTER_ASSETS_BY_CLASS_PATH
+			return AssetRegistry.GetAssetByObjectPath(FSoftObjectPath(*Item->DisplayText.ToString()));
+#else
+			return AssetRegistry.GetAssetByObjectPath(*Item->DisplayText.ToString());
+#endif // FILTER_ASSETS_BY_CLASS_PATH
+		});
+
+	return OutTargetAssets;
+}
+
+TMap<FString, FAssetData> GetConfirmedAssets(
+	const FString& ClassName, const TArray<FAssetData>& InAssets)
+{
+	TMap<FString, FAssetData> OutResults;
+
+	AssetHelpers::ForEachAsset(InAssets,
+		[&](UBlueprintGeneratedClass* BlueprintClassName, const FAssetData AssetData)
+		{
+			auto It = Algo::FindByPredicate(BlueprintClassName->CalledFunctions,
+			[&](const UFunction* Fn)
+				{
+					return Fn->HasAnyFunctionFlags(EFunctionFlags::FUNC_Native)
+						&& Fn->GetOwnerClass()->GetName() != ClassName;
+				});
+
+			if (It != nullptr)
+			{
+				OutResults.Add(BlueprintClassName->GetName(), AssetData);
+			}
+		});
+
+	return OutResults;
+}
+using JsonWriter = TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>;
+
+static void SerializeBlueprintReference(
+	TSharedRef<JsonWriter>& Json, const FString& BlueprintClassName, const FAssetData& Asset)
+{
+	FString PackageFileName;
+	FString PackageFile;
+	FString PackageFilePath;
+	if (FPackageName::TryConvertLongPackageNameToFilename(Asset.GetPackage()->GetName(), PackageFileName) &&
+		FPackageName::FindPackageFileWithoutExtension(PackageFileName, PackageFile))
+	{
+		PackageFilePath = FPaths::ConvertRelativePathToFull(MoveTemp(PackageFile));
+	}
+	else
+	{
+		PackageFilePath = "[Invalid file path]";
+	}
+
+	Json->WriteObjectStart();
+	Json->WriteValue(TEXT("name"), BlueprintClassName);
+	Json->WriteValue(TEXT("path"), PackageFilePath);
+	Json->WriteObjectEnd();
+}
+
+static void SerializeBlueprints(
+	TSharedRef<JsonWriter>& Json, const TMap<FString, FAssetData>& InAssets)
+{
+	Json->WriteIdentifierPrefix(TEXT("blueprints"));
+	Json->WriteArrayStart();
+
+	for (auto& Item : InAssets)
+	{
+		const FString& BlueprintClassName = Item.Key;
+		const FAssetData& Asset = Item.Value;
+		SerializeBlueprintReference(Json, BlueprintClassName, Asset);
+	}
+
+	Json->WriteArrayEnd();
+}
+
+static void SerializeMetadata(
+	TSharedRef<JsonWriter>& Json, int TotalAssetCount)
+{
+	Json->WriteIdentifierPrefix(TEXT("metadata"));
+	Json->WriteObjectStart();
+	{
+		Json->WriteValue(TEXT("asset_count"), TotalAssetCount);
+	}
+	Json->WriteObjectEnd();
+}
+
+static void SerializeResults(
+	const TMap<FString, FAssetData>& InAssets,
+	FArchive& OutArchive,
+	int TotalAssetCount)
+{
+	TSharedRef<JsonWriter> Json = JsonWriter::Create(&OutArchive);
+	Json->WriteObjectStart();
+
+	SerializeBlueprints(Json, InAssets);
+	SerializeMetadata(Json, TotalAssetCount);
+
+	Json->WriteObjectEnd();
+	Json->Close();
+}
+} // namespace VisualStudioTools
+
+static constexpr auto SymbolParamVal = TEXT("symbol");
+
+UVsBlueprintReferencesCommandlet::UVsBlueprintReferencesCommandlet()
+	: Super()
+{
+	HelpDescription = TEXT("Commandlet for generating data used by Blueprint support in Visual Studio.");
+
+	HelpParamNames.Add(SymbolParamVal);
+	HelpParamDescriptions.Add(TEXT("[Optional] Fully qualified symbol to search for in the blueprints."));
+
+	HelpUsage = TEXT("<Editor-Cmd.exe> <path_to_uproject> -run=VsBlueprintReferences -output=<path_to_output_file> -symbol=<ClassName::FunctionName> [-unattended -noshadercompile -nosound -nullrhi -nocpuprofilertrace -nocrashreports -nosplash]");
+}
+
+int32 UVsBlueprintReferencesCommandlet::Run(
+	TArray<FString>& Tokens,
+	TArray<FString>& Switches,
+	TMap<FString, FString>& ParamVals,
+	FArchive& OutArchive)
+{
+	GIsRunning = true; // Required for the blueprint search to work.
+
+	FString* ReferencesSymbol = ParamVals.Find(SymbolParamVal);
+	if (ReferencesSymbol->IsEmpty())
+	{
+		UE_LOG(LogVisualStudioTools, Error, TEXT("Missing required symbol parameter."));
+		PrintHelp();
+		return -1;
+	}
+
+	FString Function;
+	FString ClassNameNative;
+	if (!ReferencesSymbol->Split(TEXT("::"), &ClassNameNative, &Function))
+	{
+		UE_LOG(LogVisualStudioTools, Error, TEXT("Reference parameter should be in the qualified 'NativeClassName::MethodName' format."));
+		PrintHelp();
+		return -1;
+	}
+
+	FString ClassName = VisualStudioTools::StripClassPrefix(std::move(ClassNameNative));
+	FString SearchValue = FString::Printf(TEXT("Nodes(\"Native Name\"=+%s & ClassName=K2Node_CallFunction)"), *Function, *ClassName);
+	UE_LOG(LogVisualStudioTools, Display, TEXT("Blueprint search query: %s"), *SearchValue);
+
+	TArray<FAssetData> TargetAssets = VisualStudioTools::GetMatchingAssetsForSearchQuery(SearchValue);
+	TMap<FString, FAssetData> MatchAssets = VisualStudioTools::GetConfirmedAssets(ClassName, TargetAssets);
+	VisualStudioTools::SerializeResults(MatchAssets, OutArchive, TargetAssets.Num());
+
+	UE_LOG(LogVisualStudioTools, Display, TEXT("Found %d blueprints."), MatchAssets.Num());
+	return 0;
+}

--- a/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.h
+++ b/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.h
@@ -6,16 +6,17 @@
 #include "CoreMinimal.h"
 #include "VisualStudioToolsCommandletBase.h"
 
-#include "VisualStudioToolsCommandlet.generated.h"
+#include "BlueprintReferencesCommandlet.generated.h"
 
 UCLASS()
-class UVisualStudioToolsCommandlet
+class UVsBlueprintReferencesCommandlet
 	: public UVisualStudioToolsCommandletBase
 {
 	GENERATED_BODY()
 
 public:
-	UVisualStudioToolsCommandlet();
+	UVsBlueprintReferencesCommandlet();
+
 	int32 Run(
 		TArray<FString>& Tokens,
 		TArray<FString>& Switches,

--- a/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.cpp
+++ b/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.cpp
@@ -1,0 +1,82 @@
+// Copyright 2022 (c) Microsoft. All rights reserved.
+// Licensed under the MIT License.
+
+#include "VisualStudioToolsCommandletBase.h"
+
+#include "VisualStudioTools.h"
+
+static constexpr auto HelpSwitch = TEXT("help");
+static constexpr auto OutputSwitch = TEXT("output");
+
+UVisualStudioToolsCommandletBase::UVisualStudioToolsCommandletBase()
+{
+	IsClient = false;
+	IsEditor = true;
+	IsServer = false;
+	LogToConsole = false;
+	ShowErrorCount = false;
+
+	HelpParamNames.Add(OutputSwitch);
+	HelpParamDescriptions.Add(TEXT("[Required] The file path to write the command output."));
+
+	HelpParamNames.Add(HelpSwitch);
+	HelpParamDescriptions.Add(TEXT("[Optional] Print this help message and quit the commandlet immediately."));
+}
+
+void UVisualStudioToolsCommandletBase::PrintHelp() const
+{
+	UE_LOG(LogVisualStudioTools, Display, TEXT("%s"), *HelpDescription);
+	UE_LOG(LogVisualStudioTools, Display, TEXT("Usage: %s"), *HelpUsage);
+	UE_LOG(LogVisualStudioTools, Display, TEXT("Parameters:"));
+	for (int32 i = 0; i < HelpParamNames.Num(); ++i)
+	{
+		UE_LOG(LogVisualStudioTools, Display, TEXT("\t-%s: %s"), *HelpParamNames[i], *HelpParamDescriptions[i]);
+	}
+}
+
+int32 UVisualStudioToolsCommandletBase::Main(const FString& Params)
+{
+	TArray<FString> Tokens;
+	TArray<FString> Switches;
+	TMap<FString, FString> ParamVals;
+
+	ParseCommandLine(*Params, Tokens, Switches, ParamVals);
+
+	if (Switches.Contains(HelpSwitch))
+	{
+		PrintHelp();
+		return 0;
+	}
+
+	UE_LOG(LogVisualStudioTools, Display, TEXT("Init VS Tools cmdlet."));
+
+	if (!FPaths::IsProjectFilePathSet())
+	{
+		UE_LOG(LogVisualStudioTools, Error, TEXT("You must invoke this commandlet with a project file."));
+		return -1;
+	}
+
+	FString FullPath = ParamVals.FindRef(OutputSwitch);
+
+	if (FullPath.IsEmpty() && !FParse::Value(*Params, TEXT("output "), FullPath))
+	{
+		// VS:1678426 - Initial version was using `-output "path-to-file"` (POSIX style).
+		// However, that does not support paths with spaces, even when surrounded with
+		// quotes because `FParse::Value` only handles that case when there's no space
+		// between the parameter name and quoted value.
+		// For back-compatibility reasons, parse that style by including the space in
+		// the parameter token like it's usually done for the `=` sign.
+		UE_LOG(LogVisualStudioTools, Error, TEXT("Missing file output parameter."));
+		PrintHelp();
+		return -1;
+	}
+
+	TUniquePtr<FArchive> OutArchive{ IFileManager::Get().CreateFileWriter(*FullPath) };
+	if (!OutArchive)
+	{
+		UE_LOG(LogVisualStudioTools, Error, TEXT("Failed to create index with path: %s."), *FullPath);
+		return -1;
+	}
+
+    return this->Run(Tokens, Switches, ParamVals, *OutArchive);
+}

--- a/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.h
+++ b/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.h
@@ -1,0 +1,29 @@
+// Copyright 2022 (c) Microsoft. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Commandlets/Commandlet.h"
+
+#include "VisualStudioToolsCommandletBase.generated.h"
+
+UCLASS(Abstract)
+class UVisualStudioToolsCommandletBase
+	: public UCommandlet
+{
+	GENERATED_BODY()
+
+public:
+	int32 Main(const FString& Params) override;
+
+protected:
+	UVisualStudioToolsCommandletBase();
+	
+	void PrintHelp() const;
+
+	virtual int32 Run(
+		TArray<FString>& Tokens,
+		TArray<FString>& Switches,
+		TMap<FString, FString>& ParamVals,
+		FArchive& OutArchive) PURE_VIRTUAL(UVisualStudioToolsCommandletBase::Run, return 0;);
+};

--- a/Source/VisualStudioTools/VisualStudioTools.Build.cs
+++ b/Source/VisualStudioTools/VisualStudioTools.Build.cs
@@ -13,17 +13,17 @@ public class VisualStudioTools : ModuleRules
         // OptimizeCode = CodeOptimization.Never;
 
         // To support UE5.1+, the code is using the new FTopLevelAssetPath API
-		// with a detection of support via version numbers.
-		// If the check is producing a false positive/negative in your version of the engine
-		// you can change the block below and force the check as enabled/disabled.
-		if ((Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 1) || Target.Version.MajorVersion > 5)
-		{
-			PrivateDefinitions.Add("FILTER_ASSETS_BY_CLASS_PATH=1");
-		}
-		else
-		{
-			PrivateDefinitions.Add("FILTER_ASSETS_BY_CLASS_PATH=0");
-		}
+        // with a detection of support via version numbers.
+        // If the check is producing a false positive/negative in your version of the engine
+        // you can change the block below and force the check as enabled/disabled.
+        if ((Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 1) || Target.Version.MajorVersion > 5)
+        {
+            PrivateDefinitions.Add("FILTER_ASSETS_BY_CLASS_PATH=1");
+        }
+        else
+        {
+            PrivateDefinitions.Add("FILTER_ASSETS_BY_CLASS_PATH=0");
+        }
 
         PublicDependencyModuleNames.AddRange(
             new[]
@@ -40,8 +40,8 @@ public class VisualStudioTools : ModuleRules
                 "Engine",
                 "Json",
                 "JsonUtilities",
-				"Kismet",
-				"UnrealEd",
+                "Kismet",
+                "UnrealEd",
             }
         );
     }

--- a/Source/VisualStudioTools/VisualStudioTools.Build.cs
+++ b/Source/VisualStudioTools/VisualStudioTools.Build.cs
@@ -10,7 +10,7 @@ public class VisualStudioTools : ModuleRules
 
         // When debugging the commandlet code, you can uncomment the line below
         // to get proper local variable inspection and less inlined stack frames
-        //OptimizeCode = CodeOptimization.Never;
+        // OptimizeCode = CodeOptimization.Never;
 
         // To support UE5.1+, the code is using the new FTopLevelAssetPath API
 		// with a detection of support via version numbers.
@@ -40,7 +40,8 @@ public class VisualStudioTools : ModuleRules
                 "Engine",
                 "Json",
                 "JsonUtilities",
-                "UnrealEd",
+				"Kismet",
+				"UnrealEd",
             }
         );
     }


### PR DESCRIPTION
- Refactor common code into a base commandlet class
- Refactor code that loads assets into wrapper for iteration
- Add new sub-class for blueprint search, using the UE Find In Blueprints (FiB) components
- Visual Studio will invoke the new commandlet in the new Find All BP References feature