### PR TITLE
Adding missing includes

### DIFF
--- a/Source/VisualStudioTools/Private/BlueprintAssetHelper.cpp
+++ b/Source/VisualStudioTools/Private/BlueprintAssetHelper.cpp
@@ -5,6 +5,8 @@
 
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Engine/BlueprintGeneratedClass.h"
+#include "Engine/BlueprintCore.h"
+#include "Engine/Engine.h"
 #include "Engine/StreamableManager.h"
 #include "Misc/ScopeExit.h"
 #include "VisualStudioTools.h"

--- a/Source/VisualStudioTools/Private/BlueprintAssetHelper.cpp
+++ b/Source/VisualStudioTools/Private/BlueprintAssetHelper.cpp
@@ -4,8 +4,8 @@
 #include "BlueprintAssetHelpers.h"
 
 #include "AssetRegistry/AssetRegistryModule.h"
-#include "Engine/BlueprintGeneratedClass.h"
 #include "Engine/BlueprintCore.h"
+#include "Engine/BlueprintGeneratedClass.h"
 #include "Engine/Engine.h"
 #include "Engine/StreamableManager.h"
 #include "Misc/ScopeExit.h"

--- a/Source/VisualStudioTools/Private/BlueprintAssetHelpers.h
+++ b/Source/VisualStudioTools/Private/BlueprintAssetHelpers.h
@@ -3,6 +3,9 @@
 
 #pragma once
 #include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+
+class UBlueprintGeneratedClass;
 
 namespace VisualStudioTools 
 {

--- a/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.cpp
@@ -6,6 +6,7 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "BlueprintAssetHelpers.h"
 #include "Engine/BlueprintGeneratedClass.h"
+#include "Algo/Find.h"
 #include "FindInBlueprintManager.h"
 #include "JsonObjectConverter.h"
 #include "Misc/ScopeExit.h"

--- a/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.cpp
@@ -3,10 +3,10 @@
 
 #include "BlueprintReferencesCommandlet.h"
 
+#include "Algo/Find.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "BlueprintAssetHelpers.h"
 #include "Engine/BlueprintGeneratedClass.h"
-#include "Algo/Find.h"
 #include "FindInBlueprintManager.h"
 #include "JsonObjectConverter.h"
 #include "Misc/ScopeExit.h"

--- a/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.cpp
+++ b/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.cpp
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 #include "VisualStudioToolsCommandletBase.h"
-
 #include "VisualStudioTools.h"
+#include "HAL/FileManager.h"
 
 static constexpr auto HelpSwitch = TEXT("help");
 static constexpr auto OutputSwitch = TEXT("output");

--- a/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.cpp
+++ b/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.cpp
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 #include "VisualStudioToolsCommandletBase.h"
-#include "VisualStudioTools.h"
+
 #include "HAL/FileManager.h"
+#include "VisualStudioTools.h"
 
 static constexpr auto HelpSwitch = TEXT("help");
 static constexpr auto OutputSwitch = TEXT("output");


### PR DESCRIPTION
The code in main currently doesn't compile because a bunch of includes are missing.  Hypothetically this was missed because the files end up in a unity build.  However, files open for edit/add are by default omitted from unity builds and would surface this error.