### PR TITLE
Fix build break on UE4.x and update version number

### DIFF
--- a/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/BlueprintReferencesCommandlet.cpp
@@ -4,6 +4,7 @@
 #include "BlueprintReferencesCommandlet.h"
 
 #include "Algo/Find.h"
+#include "Algo/Transform.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "BlueprintAssetHelpers.h"
 #include "Engine/BlueprintGeneratedClass.h"

--- a/VisualStudioTools.uplugin
+++ b/VisualStudioTools.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "2.1",
+	"VersionName": "2.2",
 	"FriendlyName": "Visual Studio Integration Tools",
 	"Description": "Enables integration with Visual Studio IDE.",
 	"Category": "Programming",


### PR DESCRIPTION
Change version number in plugin descriptor to v2.2
Add missing include causing break in UE 4.27