### PR TITLE
Change MSBuild script to use RunUAT.bat directly

### DIFF
--- a/Scripts/build.proj
+++ b/Scripts/build.proj
@@ -1,18 +1,21 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <UnrealVersion Condition=" '$(UnrealVersion)'=='' ">5.1</UnrealVersion>
-        <OutputPath Condition=" '$(OutputPath)'=='' ">bin\</OutputPath>
         <PluginFolder>$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))</PluginFolder>
         <PluginFile>$([System.IO.Path]::Combine($(PluginFolder), `VisualStudioTools.uplugin`))</PluginFile>
-        <PackagePath>$([System.IO.Path]::Combine($(PluginFolder), $(OutputPath)))</PackagePath>
-        <PowerShellExe>$(WINDIR)\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
-        <ScriptLocation>$([System.IO.Path]::Combine($(MSBuildProjectDirectory), `Build-Plugin.ps1`))</ScriptLocation>
+        <OutputPath Condition=" '$(OutputPath)'=='' ">$([System.IO.Path]::Combine($(PluginFolder), "bin"))</OutputPath>
+        <EnginePath>$(UnrealEngine)</EnginePath>
+        <EnginePath Condition="!Exists('$(EnginePath)')">
+            $([MSBuild]::GetRegistryValue('HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine\$(UnrealEngine)', 'InstalledDirectory')) 
+        </EnginePath>
+        <UATScript>$(EnginePath.Trim())\Engine\Build\BatchFiles\RunUAT.bat</UATScript>
+        <StrictIncludesFlag Condition=" '$(StrictIncludes)' == 'true'">-StrictIncludes</StrictIncludesFlag>
     </PropertyGroup>
     <Target Name="Build">
-        <MakeDir Directories="$(PackagePath)" Condition="!Exists('$(PackagePath)')" />
-        <Exec Command="$(PowerShellExe) -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -c &quot;&amp; { &amp; &apos;$(ScriptLocation)&apos; -InstalledVersion &quot;$(UnrealVersion)&quot; -PluginFile &apos;$(PluginFile)&apos; -CopyToTarget No -PackagePath &apos;$(PackagePath)&apos; } &quot;" />
+        <Error Text="Cannot locate the RunUAT.bat script. Check if the $UnrealEngine property is a valid path or installed version." Condition="!Exists('$(UATScript)')"></Error>
+        <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
+        <Exec Command="&quot;$(UATScript)&quot; BuildPlugin -Plugin=&quot;$(PluginFile)&quot; -TargetPlatforms=Win64 -Package=&quot;$(OutputPath)&quot; $(StrictIncludesFlag) -FromMsBuild -Unversioned" />
     </Target>
     <Target Name="Clean" >
-        <RemoveDir Directories="$(PackagePath);"/>
+        <RemoveDir Directories="$(OutputPath);"/>
     </Target>
 </Project>


### PR DESCRIPTION
Example Usages
- Source engine: `msbuild ./scripts/build.proj -p:UnrealEngine="C:\dev\ue"`
- Installed: `msbuild ./scripts/build.proj -p:UnrealEngine=5.2`

Other options include -p:StrictIncludes=true (off for now, will be default later) and -p:OutputPath