### PR TITLE
Build plugin in compliance pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ By default the script will disable Unity Builds in the plugin modules to catch e
 If you get errors due to unity build problems, you get the same errors in Visual Studio by generating the solution with the command below. This will allow Visual Studio to suggest the includes as code fixes. Note that this will overwrite any existing solution and projects that are already present.
 
 ```powershell
-$env:VSTUE_DisableUnityBuild=1; & "C:\Program Files\Epic Games\UE_5.2\Engine\Build\BatchFiles\Build.bat" -projectfiles -project="full_path_to_game.uproject" -game
+$env:VSTUE_IsCustomDevBuild=1; & "C:\Program Files\Epic Games\UE_5.2\Engine\Build\BatchFiles\Build.bat" -projectfiles -project="full_path_to_game.uproject" -game
 ```
 
 The module rules for the plugin check the enviroment variable above to use the more strict include settings.

--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -125,10 +125,10 @@ static int32 RunTests(const FString& TestListFile, const FString& ResultsFile)
 			FTaskGraphInterface::Get().ProcessThreadUntilIdle(ENamedThreads::GameThread);
 
 			const FDateTime Now = FDateTime::UtcNow();
-			const FTimespan Delta = Now - Last;
+			const float Delta = static_cast<float>((Now - Last).GetTotalSeconds());
 
 			// .. and the core FTicker
-			FTSTicker::GetCoreTicker().Tick(Delta.GetTotalSeconds());
+			FTSTicker::GetCoreTicker().Tick(Delta);
 
 			Last = Now;
 		}

--- a/Source/VisualStudioTools/VisualStudioTools.Build.cs
+++ b/Source/VisualStudioTools/VisualStudioTools.Build.cs
@@ -6,23 +6,27 @@ public class VisualStudioTools : ModuleRules
 {
     public VisualStudioTools(ReadOnlyTargetRules Target) : base(Target)
     {
-        // This is useful to get proper header suggestions in the IDE and validate 
-        // the plugin build without having to affect for the whole target, which is 
-        // expensive in source-builds of the engine.
-        bool bForceDisableUnity = System.Environment.GetEnvironmentVariable("VSTUE_DisableUnityBuild") == "1";
-        if (bForceDisableUnity)
+        bool bIsCustomDevBuild = System.Environment.GetEnvironmentVariable("VSTUE_IsCustomDevBuild") == "1";
+        if (bIsCustomDevBuild)
         {
+            // Get correct header suggestions in the IDE and validate 
+            // the plugin build without having to affect for the whole target, 
+            // which is expensive in source-builds of the engine.
             PCHUsage = ModuleRules.PCHUsageMode.NoPCHs;
             bUseUnity = false;
+
+            // When debugging the commandlet code, disable optimizations to get
+            // proper local variable inspection and less inlined stack frames
+            OptimizeCode = CodeOptimization.Never;
+
+            // Enable more restrict warnings during compilation.
+            // Required by tasks in the compliance pipeline.
+            UnsafeTypeCastWarningLevel = WarningLevel.Error;
         }
         else
         {
             PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
         }
-
-        // When debugging the commandlet code, you can uncomment the line below
-        // to get proper local variable inspection and less inlined stack frames
-        // OptimizeCode = CodeOptimization.Never;
 
         // To support UE5.1+, the code is using the new FTopLevelAssetPath API
         // with a detection of support via version numbers.

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -60,18 +60,20 @@ jobs:
     - task: CredScan@3
       inputs:
         scanFolder: '$(Build.SourcesDirectory)'
-    - task: SDLNativeRules@3
-      displayName: 'Run the PREfast SDL Native Rules for MSBuild'
-      inputs:
-        publishXML: false
-        userProvideBuildInfo: auto
-        rulesetName: Recommended
     - task: BinSkim@4
       inputs:
         InputType: 'Basic'
         Function: 'analyze'
         TargetPattern: 'guardianGlob'
         AnalyzeTargetGlob: '$(Build.ArtifactStagingDirectory)/drop/**.dll'
+    - task: SDLNativeRules@3
+      displayName: 'Run the PREfast SDL Native Rules for MSBuild'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      inputs:
+        publishXML: true
+        userProvideBuildInfo: auto
+        rulesetName: Recommended
     - task: TSAUpload@2
       displayName: 'TSA upload'
       inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -74,6 +74,7 @@ jobs:
         publishXML: true
         userProvideBuildInfo: auto
         rulesetName: Recommended
+        setupCommandlinePicker: 'vs2022'
     - task: TSAUpload@2
       displayName: 'TSA upload'
       inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -13,7 +13,7 @@ pr:
       - dev/*
 
 pool:
-  vmImage: windows-latest
+  name: VSEngSS-MicroBuild2022-1ES
 
 jobs:
 - job: 'UnrealEngine_VisualStudioTools_Compliance'

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -1,3 +1,7 @@
+variables:
+  Codeql.Enabled: true
+  Codeql.SourceRoot: '$(Build.SourcesDirectory)'
+
 trigger:
 - main
 
@@ -11,30 +15,65 @@ pr:
 pool:
   vmImage: windows-latest
 
-steps:
-- task: PoliCheck@2
-  inputs:
-    targetType: 'F'
-    targetArgument: '$(Build.SourcesDirectory)'
-
-- task: ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
-
-- task: AntiMalware@4
-  inputs:
-    InputType: 'Basic'
-    ScanType: 'CustomScan'
-    FileDirPath: '$(Build.StagingDirectory)'
-    TreatSignatureUpdateFailureAs: 'Warning'
-    SignatureFreshness: 'UpToDate'
-    TreatStaleSignatureAs: 'Error'
-
-- task: CredScan@3
-  inputs:
-    scanFolder: '$(Build.SourcesDirectory)'
-
-- task: TSAUpload@2
-  displayName: 'TSA upload'
-  inputs:
-    GdnPublishTsaOnboard: True
-    GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/azure-pipelines/TSAOptions.json'
+jobs:
+- job: 'UnrealEngine_VisualStudioTools_Compliance'
+  timeoutInMinutes: 1440
+  steps:
+    - task: CmdLine@2
+      displayName: 'Clone Unreal Engine Repository'
+      inputs:
+        script: 'git clone "https://$(token)@github.com/EpicGames/UnrealEngine" --single-branch --branch $(ue_branch) --depth 1 ue'
+        workingDirectory: '$(Agent.BuildDirectory)'
+    - task: PowerShell@2
+      displayName: '[UE] Append /unattended option'
+      inputs:
+        targetType: 'inline'
+        script:
+          $filePath = "$(Agent.BuildDirectory)/ue/Setup.bat";
+          (Get-Content $filePath).Replace("/register", "/register /unattended") | Set-Content $filePath
+    - task: CmdLine@2
+      displayName: '[UE] Run Setup.bat'
+      inputs:
+        script: 'ue\Setup.bat --force'
+        workingDirectory: '$(Agent.BuildDirectory)'
+    - task: MSBuild@1
+      displayName: 'Build Plugin'
+      timeoutInMinutes: 300
+      inputs:
+        solution: '$(Build.SourcesDirectory)/build.proj'
+        msbuildArguments: '-p:UnrealEngine=$(Agent.BuildDirectory)\ue;OutputPath=$(Build.ArtifactStagingDirectory)\drop'
+        createLogFile: true
+    - task: PoliCheck@2
+      inputs:
+        targetType: 'F'
+        targetArgument: '$(Build.SourcesDirectory)'
+    - task: ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'
+    - task: AntiMalware@4
+      inputs:
+        InputType: 'Basic'
+        ScanType: 'CustomScan'
+        FileDirPath: '$(Build.StagingDirectory)'
+        TreatSignatureUpdateFailureAs: 'Warning'
+        SignatureFreshness: 'UpToDate'
+        TreatStaleSignatureAs: 'Error'
+    - task: CredScan@3
+      inputs:
+        scanFolder: '$(Build.SourcesDirectory)'
+    - task: SDLNativeRules@3
+      displayName: 'Run the PREfast SDL Native Rules for MSBuild'
+      inputs:
+        publishXML: false
+        userProvideBuildInfo: auto
+        rulesetName: Recommended
+    - task: BinSkim@4
+      inputs:
+        InputType: 'Basic'
+        Function: 'analyze'
+        TargetPattern: 'guardianGlob'
+        AnalyzeTargetGlob: '$(Build.ArtifactStagingDirectory)/drop/**.dll'
+    - task: TSAUpload@2
+      displayName: 'TSA upload'
+      inputs:
+        GdnPublishTsaOnboard: True
+        GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/azure-pipelines/TSAOptions.json'

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -41,13 +41,15 @@ jobs:
       timeoutInMinutes: 300
       inputs:
         solution: '$(Build.SourcesDirectory)/build.proj'
-        msbuildArguments: '-p:UnrealEngine=$(Agent.BuildDirectory)\ue;OutputPath=$(Build.ArtifactStagingDirectory)\drop'
+        msbuildArguments: '/p:UnrealEngine=$(Agent.BuildDirectory)\ue /p:OutputPath=$(Build.ArtifactStagingDirectory)\drop'
         createLogFile: true
     - task: PoliCheck@2
       inputs:
         targetType: 'F'
         targetArgument: '$(Build.SourcesDirectory)'
     - task: ComponentGovernanceComponentDetection@0
+      inputs:
+        ignoreDirectories: '$(Agent.BuildDirectory)\ue'
       displayName: 'Component Detection'
     - task: AntiMalware@4
       inputs:

--- a/build.proj
+++ b/build.proj
@@ -11,11 +11,11 @@
         <UnversionedFlag Condition=" '$(Versioned)' != 'true'">-Unversioned</UnversionedFlag>
     </PropertyGroup>
     <Target Name="Build">
-        <Error Text="Cannot locate the RunUAT.bat script. Check if the $UnrealEngine property is a valid path or installed version." Condition="!Exists('$(UATScript)')"></Error>
+        <Error Text="Cannot locate the RunUAT.bat script at $(UATScript). Check if the $UnrealEngine property is a valid path or installed version." Condition="!Exists('$(UATScript)')"></Error>
         <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
         <Exec 
             Command="&quot;$(UATScript)&quot; BuildPlugin -Plugin=&quot;$(PluginFile)&quot; -TargetPlatforms=Win64 -Package=&quot;$(OutputPath)&quot; $(UnversionedFlag) -FromMsBuild" 
-            EnvironmentVariables="VSTUE_DisableUnityBuild=1"/>
+            EnvironmentVariables="VSTUE_IsCustomDevBuild=1"/>
     </Target>
     <Target Name="Clean" >
         <RemoveDir Directories="$(OutputPath);"/>


### PR DESCRIPTION
Extend the current compliance pipeline to:
- Checkout a local version of the Unreal Engine
- Build the plugin using the local UE
- Run extra tasks that require binary outputs