### PR TITLE
Update /Package-Plugin.ps1 to find RunUAT.bat for pre-release engine versions

### DIFF
--- a/Scripts/Package-Plugin.ps1
+++ b/Scripts/Package-Plugin.ps1
@@ -1,6 +1,9 @@
 param(
    [Parameter(Mandatory=$true)]
    [string]
+   $EnginePath,
+   [Parameter(Mandatory=$true)]
+   [string]
    $EngineVersion
 )
 
@@ -11,8 +14,7 @@ function New-TemporaryDirectory {
 }
 
 $PackagePath = New-TemporaryDirectory
-
-& msbuild "-p:UnrealEngine=$EngineVersion;OutputPath=$PackagePath;Versioned=true"
+& msbuild "-p:UnrealEngine=$EnginePath;OutputPath=$PackagePath;Versioned=true"
 
 # Add EnabledByDefault property in the descriptor file
 Write-Host "Patch plugin descriptor file"


### PR DESCRIPTION
Previously the EngineVersion variable was used to pass both engine versions or paths to the engine. This caused an error for pre-release engine versions that require a clone from GitHub. This error was caused, because a path contains characters ('/' or '\') that break our .zip file generation. For example, in the previous functionality, passing the path for UE 5.3 source engine 'C:/src/UE_5.3' would create a zip file VisualStudioTools_v2.3_ueC:/src/UE_5.3.zip. Now, we have two variables EnginePath (the path to the engine we want to build the plugin with), and EngineVersion (just the engine version number we add to the end of the .zip file name).