### PR TITLE
Set Installed to false inside uplugin

### DIFF
--- a/VisualStudioTools.uplugin
+++ b/VisualStudioTools.uplugin
@@ -11,6 +11,7 @@
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/362651520df94e4fa65492dbcba44ae2",
 	"SupportURL": "https://developercommunity.visualstudio.com/",
 	"EnabledByDefault": true,
+	"Installed": false,
 	"bExplicitlyLoaded": true,
 	"CanContainContent": false,
 	"SupportedTargetPlatforms": [


### PR DESCRIPTION
This will avoid the engine asking every time you open it to update the uproject file with the new plugins.

If we update the project file with this change, not having the plugin installed will block other team members to build the game because the missing dependency.

This plugin is a Tool, but not a requirement, so it shouldn't be a dependency, therefore it shouldn't be added to .uproject by default