### PR TITLE
Removing Priority Mask from the UE Test Adapter Filters

### DIFF
--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -214,8 +214,7 @@ int32 UVSTestAdapterCommandlet::Main(const FString& Params)
 	}
 
 	// Default to all the test filters on except for engine tests.
-	uint32 filter = EAutomationTestFlags::PriorityMask |
-					EAutomationTestFlags::ProductFilter | EAutomationTestFlags::SmokeFilter |
+	uint32 filter = EAutomationTestFlags::ProductFilter | EAutomationTestFlags::SmokeFilter |
 					EAutomationTestFlags::PerfFilter | EAutomationTestFlags::StressFilter | EAutomationTestFlags::NegativeFilter;
 	if (ParamVals.Contains(FiltersParam))
 	{


### PR DESCRIPTION
Note: The PriorityMask filter covers any priority tag (low, medium, high priority, etc.)
Usually, these priority tags is used in conjunction with other test tags (engine, product, etc.). There's no need to have this priority mask on by default since tests that have a priority tag will be marked with some other tag as well anyways. Otherwise, we will be displaying prioritized tests when we turn off all of the filters in Tools > Options which looks like a bug. Of course, this would mean tests marked ONLY with a priority tag will not be found unless another tag is added as well (engine, product, etc.). This is not likely though, so I think this is a better approach than adding a new ‘Priority’ filter under Tools > Options, which is pretty vague.