### PR TITLE
Surround Windows includes with WindowsPlatformTypes guard headers

### DIFF
--- a/Source/VisualStudioTools/Private/VSServerCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSServerCommandlet.cpp
@@ -3,6 +3,8 @@
 #include "VSServerCommandlet.h"
 #include "VSTestAdapterCommandlet.h"
 
+#include "Windows/AllowWindowsPlatformTypes.h"
+
 #include "HAL/PlatformNamedPipe.h"
 #include "Runtime/Core/Public/Async/TaskGraphInterfaces.h"
 #include "Runtime/Core/Public/Containers/Ticker.h"
@@ -16,6 +18,8 @@
 #include <string>
 #include <thread>
 #include <windows.h>
+
+#include "Windows/HideWindowsPlatformTypes.h"
 
 #include "VisualStudioTools.h"
 

--- a/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.cpp
+++ b/Source/VisualStudioTools/Private/VisualStudioToolsCommandletBase.cpp
@@ -3,9 +3,13 @@
 
 #include "VisualStudioToolsCommandletBase.h"
 
+#include "Windows/AllowWindowsPlatformTypes.h"
+
 #include "HAL/FileManager.h"
 #include "Misc/Paths.h"
 #include "VisualStudioTools.h"
+
+#include "Windows/HideWindowsPlatformTypes.h"
 
 static constexpr auto HelpSwitch = TEXT("help");
 static constexpr auto OutputSwitch = TEXT("output");


### PR DESCRIPTION
Trying to build the project on UE 5.1 without `WindowsPlatformTypes` guards results in compilation errors, such as errors triggered by `TEXT` macro redefinition.