### PR TITLE
Run the pipeline weekly

### DIFF
--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -16,6 +16,14 @@ pr:
     - main
     - dev/*
 
+schedules:
+  - cron: "0 12 * * Sun"
+    displayName: Weekly run
+    branches:
+      include:
+        - main
+    always: true
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates


### PR DESCRIPTION
Must run CodeQL every 30 days to meet compliance requirements. Just schedule the run weekly which meets the requirements.