### PR TITLE
Fix compatibility with new enum types in ue5-main branch

### DIFF
--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -214,7 +214,7 @@ int32 UVSTestAdapterCommandlet::Main(const FString& Params)
 	}
 
 	// Default to all the test filters.
-	uint32 filter = EAutomationTestFlags::ProductFilter | EAutomationTestFlags::SmokeFilter | EAutomationTestFlags::PerfFilter | EAutomationTestFlags::EngineFilter;
+	auto filter = EAutomationTestFlags::ProductFilter | EAutomationTestFlags::SmokeFilter | EAutomationTestFlags::PerfFilter | EAutomationTestFlags::EngineFilter;
 	if (ParamVals.Contains(FiltersParam))
 	{
 		FString filters = ParamVals[FiltersParam];


### PR DESCRIPTION
`vc-ue-extensions` fails to build after recent changes in `ue5-main` branch of Unreal Engine, because `EAutomationTestFlags` is now `enum class`, not an old-style C-enum.

Making `filter` variable declared as `auto` so it will compile well with both old and new versions of engine.