### PR TITLE
feat: add release pipeline

### DIFF
--- a/Scripts/SignDetached.proj
+++ b/Scripts/SignDetached.proj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="SignFiles" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
+
+  <PropertyGroup>
+  <BaseOutputDirectory>$(MSBuildThisFileDirectory)../../out/</BaseOutputDirectory>
+    <!-- These properties are required by MicroBuild, which only signs files that are under these paths -->
+    <IntermediateOutputPath>$(BaseOutputDirectory)</IntermediateOutputPath>
+    <OutDir>$(BaseOutputDirectory)</OutDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FilesToSign Include="$(OutDir)\VisualStudioTools.zip.cat">
+      <Authenticode>Microsoft400</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
+
+  <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.0.4.1\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" />
+</Project>

--- a/Scripts/packages.config
+++ b/Scripts/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="0.4.1" targetFramework="native" developmentDependency="true" />
+</packages>

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -75,7 +75,7 @@ extends:
               command: 'restore'
               restoreSolution: 'Scripts/SignDetached.proj'
               feedsToUse: 'config'
-              restoreDirectory: '$(Build.SourcesDirectory)\packages'
+              restoreDirectory: '$(Build.SourcesDirectory)\Scripts\packages'
           - task: MSBuild@1
             displayName: Sign catalogs
             inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -49,6 +49,21 @@ extends:
       jobs:
       - job: 'UnrealEngine_VisualStudioTools_Release'
         timeoutInMinutes: 1440
+        templateContext:
+          outputParentDirectory: $(Agent.BuildDirectory)/out/
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish zip'
+            targetPath: $(Agent.BuildDirectory)/out/VisualStudioTools.zip
+            artifactName: VisualStudioTools.zip
+            artifactType: container
+            sbomEnabled: false
+          - output: pipelineArtifact
+            displayName: 'Publish cat'
+            targetPath: $(Agent.BuildDirectory)/out/VisualStudioTools.zip.cat
+            artifactName: VisualStudioTools.zip.cat
+            artifactType: container
+            sbomEnabled: false
         steps:
           - task: MicroBuildSigningPlugin@4
             displayName: Install MicroBuild Signing
@@ -90,16 +105,6 @@ extends:
               Get-ChildItem -Path $(Agent.BuildDirectory) -Recurse
             displayName: Show files
             workingDirectory: '$(Build.SourcesDirectory)'
-          - task: PublishPipelineArtifact@1
-            displayName: Publish VisualStudioTools.zip Artifact
-            inputs:
-              path: '$(Agent.BuildDirectory)/out/VisualStudioTools.zip'
-              artifactName: VisualStudioTools.zip
-          - task: PublishPipelineArtifact@1
-            displayName: Publish VisualStudioTools.zip.cat Artifact
-            inputs:
-              path: '$(Agent.BuildDirectory)/out/VisualStudioTools.zip.cat'
-              artifactName: VisualStudioTools.zip.cat
 
             # Commenting for now for polishin the pipeline
             # - bash: |

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -81,6 +81,11 @@ extends:
             inputs:
               solution: Scripts/SignDetached.proj
               msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
+          - task: ExtractFiles@1
+            displayName: Extract zip file
+            inputs:
+              archiveFilePatterns: '$(Agent.BuildDirectory)/out/VisualStudioTools.zip'
+              destinationFolder: '$(Agent.BuildDirectory)/out/ExtractedFiles'
           - powershell: |
               Get-ChildItem -Path $(Agent.BuildDirectory) -Recurse
             displayName: Show files

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -9,7 +9,7 @@ variables:
   TeamName: C++ Unreal Engine
   # only test-sign for now
   SignType: test
-  TagName: HEAD # $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
+  TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
 
 trigger:
 - main
@@ -66,7 +66,7 @@ extends:
             sbomEnabled: false
         steps:
           - powershell: |
-              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
+              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse HEAD)"
             displayName: Save tag commit hash
             workingDirectory: '$(Build.SourcesDirectory)'
           - task: MicroBuildSigningPlugin@4

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -72,7 +72,6 @@ extends:
               zipSources: true
           - task: PowerShell@2
             displayName: "Create zip excluding .git folder"
-            workingDirectory: '$(Agent.BuildDirectory)'
             inputs:
               targetType: 'inline'
               script: |

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -66,6 +66,13 @@ extends:
           - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
             displayName: Create standalone zip catalog
             workingDirectory: '$(Agent.BuildDirectory)\out'
+           - task: NuGetCommand@2
+            displayName: 'NuGet Restore MicroBuild Signing Extension'
+            inputs:
+              command: 'restore'
+              restoreSolution: 'Scripts/SignDetached.proj'
+              feedsToUse: 'config'
+              restoreDirectory: '$(Build.SourcesDirectory)\packages'
           - task: MSBuild@1
             displayName: Sign catalogs
             inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -9,7 +9,7 @@ variables:
   TeamName: C++ Unreal Engine
   # only test-sign for now
   SignType: test
-  TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
+  TagName: HEAD # $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
 
 trigger:
 - main

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -31,6 +31,13 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
+variables:
+  # MicroBuild requires TeamName to be set.
+  TeamName: C++ Unreal Engine
+  # only test-sign for now
+  SignType: test
+  TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
@@ -42,82 +49,54 @@ extends:
     stages:
     - stage: stage
       jobs:
-      - job: 'UnrealEngine_VisualStudioTools_Compliance'
+      - job: 'UnrealEngine_VisualStudioTools_Release'
         timeoutInMinutes: 1440
         steps:
-        - task: CmdLine@2
-          displayName: 'Clone Unreal Engine Repository'
-          inputs:
-            script: 'git clone "https://$(token)@github.com/EpicGames/UnrealEngine" --single-branch --branch $(ue_branch) --depth 1 ue'
-            workingDirectory: '$(Agent.BuildDirectory)'
-        - task: CmdLine@2
-          displayName: 'Apply patch to allow us to pass linker flags to the build'
-          inputs:
-            script: 'git apply --ignore-whitespace $(Build.SourcesDirectory)/azure-pipelines/Support-extra-UBT-args-in-UAT.BuildPlugin.patch'
-            workingDirectory: '$(Agent.BuildDirectory)\ue'
-        - task: PowerShell@2
-          displayName: '[UE] Append /unattended option'
-          inputs:
-            targetType: 'inline'
-            script:
-              $filePath = "$(Agent.BuildDirectory)/ue/Setup.bat";
-              (Get-Content $filePath).Replace("/register", "/register /unattended") | Set-Content $filePath
-        - task: CmdLine@2
-          displayName: '[UE] Run Setup.bat'
-          inputs:
-            script: 'ue\Setup.bat --force'
-            workingDirectory: '$(Agent.BuildDirectory)'
-        - task: MSBuild@1
-          displayName: 'Build Plugin'
-          timeoutInMinutes: 300
-          inputs:
-            solution: '$(Build.SourcesDirectory)/build.proj'
-            msbuildArguments: '/p:UnrealEngine=$(Agent.BuildDirectory)\ue /p:OutputPath=$(Build.ArtifactStagingDirectory)\drop /p:VulkanReadyBinaries=true'
-            createLogFile: true
-        - task: CopyFiles@2
-          displayName: 'Collect binaries to analyze'
-          inputs:
-            SourceFolder: '$(Build.ArtifactStagingDirectory)\drop'
-            Contents: '**\unrealeditor-visualstudiotools.*'
-            TargetFolder: '$(Build.ArtifactStagingDirectory)\binariesToAnalyze'
-            CleanTargetFolder: true
-            OverWrite: true
-        - task: PoliCheck@2
-          inputs:
-            targetType: 'F'
-            targetArgument: '$(Build.SourcesDirectory)'
-        - task: ComponentGovernanceComponentDetection@0
-          inputs:
-            ignoreDirectories: '$(Agent.BuildDirectory)\ue'
-          displayName: 'Component Detection'
-        - task: APIScan@2
-          displayName: 'Run APIScan'
-          inputs:
-            softwareFolder: '$(Build.ArtifactStagingDirectory)/binariesToAnalyze'
-            softwareName: 'Visual Studio Tools for Unreal Engine'
-            softwareVersionNum: '2.4'
-            softwareBuildNum: '$(Build.BuildId)'
-            toolVersion: 'Latest'
-          env:
-            AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
-        - task: SDLNativeRules@3
-          displayName: 'Run the PREfast SDL Native Rules for MSBuild'
-          env:
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          inputs:
-            publishXML: true
-            userProvideBuildInfo: auto
-            rulesetName: Recommended
-            setupCommandlinePicker: 'vs2022'
-        - task: PublishSecurityAnalysisLogs@3
-          displayName: 'Publish security analysis logs'
-          inputs:
-            ArtifactName: 'CodeAnalysisLogs'
-            ArtifactType: 'Container'
-            AllTools: true
-            ToolLogsNotFoundAction: 'Standard'
-        - task: TSAUpload@2
-          displayName: 'TSA upload'
-          inputs:
-            GdnPublishTsaOnboard: True
-            GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/azure-pipelines/TSAOptions.json'
+          - task: MicroBuildSigningPlugin@4
+            displayName: Install MicroBuild Signing
+            inputs:
+              signType: $(SignType)
+              zipSources: true
+            - task: ArchiveFiles@2
+              displayName: Create zip from source folder
+              inputs:
+                rootFolderOrFile: $(Build.SourcesDirectory)
+                includeRootFolder: false
+                archiveType: zip
+                archiveFile: $(Agent.BuildDirectory)/out/VisualStudioTools.zip
+                replaceExistingArchive: true
+            - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
+              displayName: Create standalone zip catalog
+              workingDirectory: '$(Agent.BuildDirectory)\out'
+            - task: MSBuild@1
+              displayName: Sign catalogs
+              inputs:
+                solution: Scripts/SignDetached.proj
+                msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
+            - bash: |
+                echo "ls -lR $(Agent.BuildDirectory)"
+              displayName: Show files
+              workingDirectory: '$(Build.SourcesDirectory)'
+            
+            # Commenting for now for polishin the pipeline
+            # - bash: |
+            #     echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
+            #   displayName: Set tag commit hash
+            #   workingDirectory: '$(Build.SourcesDirectory)'
+            # - task: GitHubRelease@0
+            #   displayName: Publish to public repo
+            #   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+            #   inputs:
+            #     gitHubConnection: github/xilaraux
+            #     repositoryName: microsoft/vc-ue-extensions
+            #     action: create
+            #     target: $(SHA1)
+            #     tagSource: manual
+            #     tag: $(TagName)
+            #     title: $(TagName)
+            #     isDraft: false
+            #     isPreRelease: true
+            #     addChangeLog: false
+            #     assets: |
+            #        $(Agent.BuildDirectory)\out\VisualStudioTools.zip
+            #        $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -65,6 +65,10 @@ extends:
             artifactType: container
             sbomEnabled: false
         steps:
+          - powershell: |
+              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
+            displayName: Save tag commit hash
+            workingDirectory: '$(Agent.BuildDirectory)'
           - task: MicroBuildSigningPlugin@4
             displayName: Install MicroBuild Signing
             inputs:
@@ -77,7 +81,7 @@ extends:
               script: |
                 $destinationDirectory = "$(Agent.BuildDirectory)/out"
                 New-Item -Path $destinationDirectory -ItemType Directory
-                git archive -o "$destinationDirectory/VisualStudioTools.zip" $(TagName)
+                git archive -o "$destinationDirectory/VisualStudioTools.zip" $(SHA1)
           - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
             displayName: Create standalone catalog
             workingDirectory: '$(Agent.BuildDirectory)\out'
@@ -107,10 +111,6 @@ extends:
             workingDirectory: '$(Build.SourcesDirectory)'
 
             # Commenting for now for polishin the pipeline
-            # - bash: |
-            #     echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
-            #   displayName: Set tag commit hash
-            #   workingDirectory: '$(Build.SourcesDirectory)'
             # - task: GitHubRelease@0
             #   displayName: Publish to public repo
             #   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -70,14 +70,20 @@ extends:
             inputs:
               signType: $(SignType)
               zipSources: true
-          - task: ArchiveFiles@2
-            displayName: Create zip from source folder
+          - task: PowerShell@2
+            displayName: "Create zip excluding .git folder"
             inputs:
-              rootFolderOrFile: $(Build.SourcesDirectory)
-              includeRootFolder: false
-              archiveType: zip
-              archiveFile: $(Agent.BuildDirectory)/out/VisualStudioTools.zip
-              replaceExistingArchive: true
+              targetType: 'inline'
+              script: |
+                $sourcePath = "$(Build.SourcesDirectory)"
+                $destinationPath = "$(Agent.BuildDirectory)/out/VisualStudioTools.zip"
+                $excludePath = "$sourcePath\.git"
+                
+                # Get all files except those in the .git folder
+                $filesToZip = Get-ChildItem -Path $sourcePath -Recurse -File | Where-Object { $_.FullName -notlike "$excludePath*" }
+                
+                # Create the zip file
+                Compress-Archive -Path $filesToZip.FullName -DestinationPath $destinationPath -Force
           - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
             displayName: Create standalone zip catalog
             workingDirectory: '$(Agent.BuildDirectory)\out'

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -72,18 +72,15 @@ extends:
               zipSources: true
           - task: PowerShell@2
             displayName: "Create zip excluding .git folder"
+            workingDirectory: '$(Agent.BuildDirectory)'
             inputs:
               targetType: 'inline'
               script: |
-                $sourcePath = "$(Build.SourcesDirectory)"
-                $destinationPath = "$(Agent.BuildDirectory)/out/VisualStudioTools.zip"
-                $excludePath = "$sourcePath\.git"
-
-                New-Item -Path "$(Agent.BuildDirectory)/out" -ItemType Directory
-                $filesToZip = Get-ChildItem -Path $sourcePath -Recurse -File | Where-Object { $_.FullName -notlike "$excludePath*" }
-                Compress-Archive -Path $filesToZip.FullName -DestinationPath $destinationPath -Force
+                $destinationDirectory = "$(Agent.BuildDirectory)/out"
+                New-Item -Path $destinationDirectory -ItemType Directory
+                git archive -o "$destinationDirectory/VisualStudioTools.zip" $(TagName)
           - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
-            displayName: Create standalone zip catalog
+            displayName: Create standalone catalog
             workingDirectory: '$(Agent.BuildDirectory)\out'
           - task: NuGetToolInstaller@1
             inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -81,11 +81,11 @@ extends:
             inputs:
               solution: Scripts/SignDetached.proj
               msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
-          - bash: |
-              echo "ls -lR $(Agent.BuildDirectory)"
+          - powershell: |
+              Get-ChildItem -Path $(Agent.BuildDirectory) -Recurse
             displayName: Show files
             workingDirectory: '$(Build.SourcesDirectory)'
-          
+
             # Commenting for now for polishin the pipeline
             # - bash: |
             #     echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -67,12 +67,12 @@ extends:
             displayName: Create standalone zip catalog
             workingDirectory: '$(Agent.BuildDirectory)\out'
           - task: NuGetCommand@2
-          displayName: 'NuGet Restore MicroBuild Signing Extension'
-          inputs:
-            command: 'restore'
-            restoreSolution: 'Scripts/SignDetached.proj'
-            feedsToUse: 'config'
-            restoreDirectory: '$(Build.SourcesDirectory)\packages'
+            displayName: 'NuGet Restore MicroBuild Signing Extension'
+            inputs:
+              command: 'restore'
+              restoreSolution: 'Scripts/SignDetached.proj'
+              feedsToUse: 'config'
+              restoreDirectory: '$(Build.SourcesDirectory)\packages'
           - task: MSBuild@1
             displayName: Sign catalogs
             inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -5,6 +5,11 @@
 variables:
   Codeql.Enabled: true
   Codeql.SourceRoot: '$(Build.SourcesDirectory)'
+  # MicroBuild requires TeamName to be set.
+  TeamName: C++ Unreal Engine
+  # only test-sign for now
+  SignType: test
+  TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
 
 trigger:
 - main
@@ -31,13 +36,6 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
-variables:
-  # MicroBuild requires TeamName to be set.
-  TeamName: C++ Unreal Engine
-  # only test-sign for now
-  SignType: test
-  TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
-
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
@@ -57,27 +55,27 @@ extends:
             inputs:
               signType: $(SignType)
               zipSources: true
-            - task: ArchiveFiles@2
-              displayName: Create zip from source folder
-              inputs:
-                rootFolderOrFile: $(Build.SourcesDirectory)
-                includeRootFolder: false
-                archiveType: zip
-                archiveFile: $(Agent.BuildDirectory)/out/VisualStudioTools.zip
-                replaceExistingArchive: true
-            - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
-              displayName: Create standalone zip catalog
-              workingDirectory: '$(Agent.BuildDirectory)\out'
-            - task: MSBuild@1
-              displayName: Sign catalogs
-              inputs:
-                solution: Scripts/SignDetached.proj
-                msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
-            - bash: |
-                echo "ls -lR $(Agent.BuildDirectory)"
-              displayName: Show files
-              workingDirectory: '$(Build.SourcesDirectory)'
-            
+          - task: ArchiveFiles@2
+            displayName: Create zip from source folder
+            inputs:
+              rootFolderOrFile: $(Build.SourcesDirectory)
+              includeRootFolder: false
+              archiveType: zip
+              archiveFile: $(Agent.BuildDirectory)/out/VisualStudioTools.zip
+              replaceExistingArchive: true
+          - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
+            displayName: Create standalone zip catalog
+            workingDirectory: '$(Agent.BuildDirectory)\out'
+          - task: MSBuild@1
+            displayName: Sign catalogs
+            inputs:
+              solution: Scripts/SignDetached.proj
+              msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
+          - bash: |
+              echo "ls -lR $(Agent.BuildDirectory)"
+            displayName: Show files
+            workingDirectory: '$(Build.SourcesDirectory)'
+          
             # Commenting for now for polishin the pipeline
             # - bash: |
             #     echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -66,7 +66,7 @@ extends:
             sbomEnabled: false
         steps:
           - powershell: |
-              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
+              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse HEAD)"
             displayName: Save tag commit hash
             workingDirectory: '$(Build.SourcesDirectory)'
           - task: MicroBuildSigningPlugin@4

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -90,6 +90,16 @@ extends:
               Get-ChildItem -Path $(Agent.BuildDirectory) -Recurse
             displayName: Show files
             workingDirectory: '$(Build.SourcesDirectory)'
+          - task: PublishPipelineArtifact@1
+            displayName: Publish VisualStudioTools.zip Artifact
+            inputs:
+              path: '$(Agent.BuildDirectory)/out/VisualStudioTools.zip'
+              artifactName: VisualStudioTools.zip
+          - task: PublishPipelineArtifact@1
+            displayName: Publish VisualStudioTools.zip.cat Artifact
+            inputs:
+              path: '$(Agent.BuildDirectory)/out/VisualStudioTools.zip.cat'
+              artifactName: VisualStudioTools.zip.cat
 
             # Commenting for now for polishin the pipeline
             # - bash: |

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -68,7 +68,7 @@ extends:
           - powershell: |
               Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
             displayName: Save tag commit hash
-            workingDirectory: '$(Agent.BuildDirectory)'
+            workingDirectory: '$(Build.SourcesDirectory)'
           - task: MicroBuildSigningPlugin@4
             displayName: Install MicroBuild Signing
             inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -78,11 +78,9 @@ extends:
                 $sourcePath = "$(Build.SourcesDirectory)"
                 $destinationPath = "$(Agent.BuildDirectory)/out/VisualStudioTools.zip"
                 $excludePath = "$sourcePath\.git"
-                
-                # Get all files except those in the .git folder
+
+                New-Item -Path "$(Agent.BuildDirectory)/out" -ItemType Directory
                 $filesToZip = Get-ChildItem -Path $sourcePath -Recurse -File | Where-Object { $_.FullName -notlike "$excludePath*" }
-                
-                # Create the zip file
                 Compress-Archive -Path $filesToZip.FullName -DestinationPath $destinationPath -Force
           - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
             displayName: Create standalone zip catalog

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -66,7 +66,7 @@ extends:
             sbomEnabled: false
         steps:
           - powershell: |
-              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse HEAD)"
+              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
             displayName: Save tag commit hash
             workingDirectory: '$(Build.SourcesDirectory)'
           - task: MicroBuildSigningPlugin@4
@@ -100,31 +100,20 @@ extends:
             inputs:
               solution: Scripts/SignDetached.proj
               msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
-          - task: ExtractFiles@1
-            displayName: Extract zip file
+          - task: GitHubRelease@1
+            displayName: Pre-release to public repo
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
             inputs:
-              archiveFilePatterns: '$(Agent.BuildDirectory)/out/VisualStudioTools.zip'
-              destinationFolder: '$(Agent.BuildDirectory)/out/ExtractedFiles'
-          - powershell: |
-              Get-ChildItem -Path $(Agent.BuildDirectory) -Recurse
-            displayName: Show files
-            workingDirectory: '$(Build.SourcesDirectory)'
-
-            # Commenting for now for polishin the pipeline
-            # - task: GitHubRelease@0
-            #   displayName: Publish to public repo
-            #   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-            #   inputs:
-            #     gitHubConnection: github/xilaraux
-            #     repositoryName: microsoft/vc-ue-extensions
-            #     action: create
-            #     target: $(SHA1)
-            #     tagSource: manual
-            #     tag: $(TagName)
-            #     title: $(TagName)
-            #     isDraft: false
-            #     isPreRelease: true
-            #     addChangeLog: false
-            #     assets: |
-            #        $(Agent.BuildDirectory)\out\VisualStudioTools.zip
-            #        $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat
+              gitHubConnection: github/xilaraux
+              repositoryName: microsoft/vc-ue-extensions
+              action: create
+              target: $(SHA1)
+              tagSource: manual
+              tag: $(TagName)
+              title: $(TagName)
+              isDraft: false
+              isPreRelease: true
+              addChangeLog: false
+              assets: |
+                  $(Agent.BuildDirectory)\out\VisualStudioTools.zip
+                  $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -66,6 +66,9 @@ extends:
           - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
             displayName: Create standalone zip catalog
             workingDirectory: '$(Agent.BuildDirectory)\out'
+          - task: NuGetToolInstaller@1
+            inputs:
+              versionSpec: 5.7
           - task: NuGetCommand@2
             displayName: 'NuGet Restore MicroBuild Signing Extension'
             inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -104,14 +104,14 @@ extends:
             displayName: Pre-release to public repo
             # condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
             inputs:
-              gitHubConnection: $(token)
+              gitHubConnection: GitHub-VSCodeExtensions
               repositoryName: microsoft/vc-ue-extensions
               action: create
               target: $(SHA1)
               tagSource: manual
               tag: $(TagName)
               title: $(TagName)
-              isDraft: false
+              isDraft: true
               isPreRelease: true
               addChangeLog: false
               assets: |

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -108,12 +108,11 @@ extends:
               repositoryName: microsoft/vc-ue-extensions
               action: create
               target: $(SHA1)
-              tagSource: manual
+              tagSource: gitTag
               tag: $(TagName)
               title: $(TagName)
               isDraft: true
               isPreRelease: true
-              addChangeLog: false
               assets: |
                   $(Agent.BuildDirectory)\out\VisualStudioTools.zip
                   $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -54,14 +54,8 @@ extends:
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish zip'
-            targetPath: $(Agent.BuildDirectory)/out/VisualStudioTools.zip
-            artifactName: VisualStudioTools.zip
-            artifactType: container
-            sbomEnabled: false
-          - output: pipelineArtifact
-            displayName: 'Publish cat'
-            targetPath: $(Agent.BuildDirectory)/out/VisualStudioTools.zip.cat
-            artifactName: VisualStudioTools.zip.cat
+            targetPath: $(Agent.BuildDirectory)/out
+            artifactName: SignedPlugin
             artifactType: container
             sbomEnabled: false
         steps:
@@ -100,19 +94,20 @@ extends:
             inputs:
               solution: Scripts/SignDetached.proj
               msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
-          - task: GitHubRelease@1
-            displayName: Pre-release to public repo
-            # condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-            inputs:
-              gitHubConnection: GitHub-VSCodeExtensions
-              repositoryName: microsoft/vc-ue-extensions
-              action: create
-              target: $(SHA1)
-              tagSource: gitTag
-              tag: $(TagName)
-              title: $(TagName)
-              isDraft: true
-              isPreRelease: true
-              assets: |
-                  $(Agent.BuildDirectory)\out\VisualStudioTools.zip
-                  $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat
+          # === Disabled for now in favor of uploading the artifacts to the pipeline ===
+          # - task: GitHubRelease@1
+          #   displayName: Pre-release to public repo
+          #   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+          #   inputs:
+          #     gitHubConnection: GitHub-VSCodeExtensions
+          #     repositoryName: microsoft/vc-ue-extensions
+          #     action: create
+          #     target: $(SHA1)
+          #     tagSource: gitTag
+          #     tag: $(TagName)
+          #     title: $(TagName)
+          #     isDraft: true
+          #     isPreRelease: true
+          #     assets: |
+          #         $(Agent.BuildDirectory)\out\VisualStudioTools.zip
+          #         $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -102,7 +102,7 @@ extends:
               msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
           - task: GitHubRelease@1
             displayName: Pre-release to public repo
-            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+            # condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
             inputs:
               gitHubConnection: $(token)
               repositoryName: microsoft/vc-ue-extensions

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -66,13 +66,13 @@ extends:
           - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
             displayName: Create standalone zip catalog
             workingDirectory: '$(Agent.BuildDirectory)\out'
-           - task: NuGetCommand@2
-            displayName: 'NuGet Restore MicroBuild Signing Extension'
-            inputs:
-              command: 'restore'
-              restoreSolution: 'Scripts/SignDetached.proj'
-              feedsToUse: 'config'
-              restoreDirectory: '$(Build.SourcesDirectory)\packages'
+          - task: NuGetCommand@2
+          displayName: 'NuGet Restore MicroBuild Signing Extension'
+          inputs:
+            command: 'restore'
+            restoreSolution: 'Scripts/SignDetached.proj'
+            feedsToUse: 'config'
+            restoreDirectory: '$(Build.SourcesDirectory)\packages'
           - task: MSBuild@1
             displayName: Sign catalogs
             inputs:

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -104,7 +104,7 @@ extends:
             displayName: Pre-release to public repo
             condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
             inputs:
-              gitHubConnection: github/xilaraux
+              gitHubConnection: $(token)
               repositoryName: microsoft/vc-ue-extensions
               action: create
               target: $(SHA1)

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -5,11 +5,6 @@
 variables:
   Codeql.Enabled: true
   Codeql.SourceRoot: '$(Build.SourcesDirectory)'
-  # MicroBuild requires TeamName to be set.
-  TeamName: C++ Unreal Engine
-  # only test-sign for now
-  SignType: test
-  TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
 
 trigger:
 - main
@@ -47,67 +42,82 @@ extends:
     stages:
     - stage: stage
       jobs:
-      - job: 'UnrealEngine_VisualStudioTools_Release'
+      - job: 'UnrealEngine_VisualStudioTools_Compliance'
         timeoutInMinutes: 1440
-        templateContext:
-          outputParentDirectory: $(Agent.BuildDirectory)/out/
-          outputs:
-          - output: pipelineArtifact
-            displayName: 'Publish zip'
-            targetPath: $(Agent.BuildDirectory)/out
-            artifactName: SignedPlugin
-            artifactType: container
-            sbomEnabled: false
         steps:
-          - powershell: |
-              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse HEAD)"
-            displayName: Save tag commit hash
-            workingDirectory: '$(Build.SourcesDirectory)'
-          - task: MicroBuildSigningPlugin@4
-            displayName: Install MicroBuild Signing
-            inputs:
-              signType: $(SignType)
-              zipSources: true
-          - task: PowerShell@2
-            displayName: "Create zip excluding .git folder"
-            inputs:
-              targetType: 'inline'
-              script: |
-                $destinationDirectory = "$(Agent.BuildDirectory)/out"
-                New-Item -Path $destinationDirectory -ItemType Directory
-                git archive -o "$destinationDirectory/VisualStudioTools.zip" $(SHA1)
-          - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
-            displayName: Create standalone catalog
-            workingDirectory: '$(Agent.BuildDirectory)\out'
-          - task: NuGetToolInstaller@1
-            inputs:
-              versionSpec: 5.7
-          - task: NuGetCommand@2
-            displayName: 'NuGet Restore MicroBuild Signing Extension'
-            inputs:
-              command: 'restore'
-              restoreSolution: 'Scripts/SignDetached.proj'
-              feedsToUse: 'config'
-              restoreDirectory: '$(Build.SourcesDirectory)\Scripts\packages'
-          - task: MSBuild@1
-            displayName: Sign catalogs
-            inputs:
-              solution: Scripts/SignDetached.proj
-              msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
-          # === Disabled for now in favor of uploading the artifacts to the pipeline ===
-          # - task: GitHubRelease@1
-          #   displayName: Pre-release to public repo
-          #   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-          #   inputs:
-          #     gitHubConnection: GitHub-VSCodeExtensions
-          #     repositoryName: microsoft/vc-ue-extensions
-          #     action: create
-          #     target: $(SHA1)
-          #     tagSource: gitTag
-          #     tag: $(TagName)
-          #     title: $(TagName)
-          #     isDraft: true
-          #     isPreRelease: true
-          #     assets: |
-          #         $(Agent.BuildDirectory)\out\VisualStudioTools.zip
-          #         $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat
+        - task: CmdLine@2
+          displayName: 'Clone Unreal Engine Repository'
+          inputs:
+            script: 'git clone "https://$(token)@github.com/EpicGames/UnrealEngine" --single-branch --branch $(ue_branch) --depth 1 ue'
+            workingDirectory: '$(Agent.BuildDirectory)'
+        - task: CmdLine@2
+          displayName: 'Apply patch to allow us to pass linker flags to the build'
+          inputs:
+            script: 'git apply --ignore-whitespace $(Build.SourcesDirectory)/azure-pipelines/Support-extra-UBT-args-in-UAT.BuildPlugin.patch'
+            workingDirectory: '$(Agent.BuildDirectory)\ue'
+        - task: PowerShell@2
+          displayName: '[UE] Append /unattended option'
+          inputs:
+            targetType: 'inline'
+            script:
+              $filePath = "$(Agent.BuildDirectory)/ue/Setup.bat";
+              (Get-Content $filePath).Replace("/register", "/register /unattended") | Set-Content $filePath
+        - task: CmdLine@2
+          displayName: '[UE] Run Setup.bat'
+          inputs:
+            script: 'ue\Setup.bat --force'
+            workingDirectory: '$(Agent.BuildDirectory)'
+        - task: MSBuild@1
+          displayName: 'Build Plugin'
+          timeoutInMinutes: 300
+          inputs:
+            solution: '$(Build.SourcesDirectory)/build.proj'
+            msbuildArguments: '/p:UnrealEngine=$(Agent.BuildDirectory)\ue /p:OutputPath=$(Build.ArtifactStagingDirectory)\drop /p:VulkanReadyBinaries=true'
+            createLogFile: true
+        - task: CopyFiles@2
+          displayName: 'Collect binaries to analyze'
+          inputs:
+            SourceFolder: '$(Build.ArtifactStagingDirectory)\drop'
+            Contents: '**\unrealeditor-visualstudiotools.*'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)\binariesToAnalyze'
+            CleanTargetFolder: true
+            OverWrite: true
+        - task: PoliCheck@2
+          inputs:
+            targetType: 'F'
+            targetArgument: '$(Build.SourcesDirectory)'
+        - task: ComponentGovernanceComponentDetection@0
+          inputs:
+            ignoreDirectories: '$(Agent.BuildDirectory)\ue'
+          displayName: 'Component Detection'
+        - task: APIScan@2
+          displayName: 'Run APIScan'
+          inputs:
+            softwareFolder: '$(Build.ArtifactStagingDirectory)/binariesToAnalyze'
+            softwareName: 'Visual Studio Tools for Unreal Engine'
+            softwareVersionNum: '2.4'
+            softwareBuildNum: '$(Build.BuildId)'
+            toolVersion: 'Latest'
+          env:
+            AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
+        - task: SDLNativeRules@3
+          displayName: 'Run the PREfast SDL Native Rules for MSBuild'
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          inputs:
+            publishXML: true
+            userProvideBuildInfo: auto
+            rulesetName: Recommended
+            setupCommandlinePicker: 'vs2022'
+        - task: PublishSecurityAnalysisLogs@3
+          displayName: 'Publish security analysis logs'
+          inputs:
+            ArtifactName: 'CodeAnalysisLogs'
+            ArtifactType: 'Container'
+            AllTools: true
+            ToolLogsNotFoundAction: 'Standard'
+        - task: TSAUpload@2
+          displayName: 'TSA upload'
+          inputs:
+            GdnPublishTsaOnboard: True
+            GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/azure-pipelines/TSAOptions.json'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -60,7 +60,7 @@ extends:
             - task: MSBuild@1
               displayName: Sign catalogs
               inputs:
-                solution: .scripts/signing/SignDetached.proj
+                solution: Scripts/SignDetached.proj
                 msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
             - bash: |
                 echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -40,7 +40,7 @@ extends:
     stages:
     - stage: stage
       jobs:
-      - job: 'UnrealEngine_VisualStudioTools_Compliance'
+      - job: 'UnrealEngine_VisualStudioTools_Release'
         timeoutInMinutes: 1440
         steps:
           - task: MicroBuildSigningPlugin@4
@@ -64,56 +64,25 @@ extends:
               inputs:
                 solution: .scripts/signing/SignDetached.proj
                 msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
-
-
-
-  # The following tasks publish to the issue-only public vcpkg-ce repo. We
-  # have a deploy key stored as a secret file in Azure Pipelines which is used
-  # to authenticate for pushing a tag and creating a release.
-  - task: DownloadSecureFile@1
-    displayName: Download deploy key
-    name: githubDeployKey
-    inputs:
-      secureFile: id_vcpkgce
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-  # GitHub has a large, regularly changing set of IP address, so ignore the
-  # hostname and allow anything with the right key.
-  # https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/about-githubs-ip-addresses
-  # This public key should have the well-known fingerprint documented below.
-  # SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
-  # https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
-  - script: mkdir %USERPROFILE%\.ssh && echo * ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==>>%USERPROFILE%\.ssh\known_hosts
-    displayName: Store GitHub public key
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-  - script: git clone git@github.com:microsoft/vcpkg-ce.git
-    displayName: Clone deployment repo
-    workingDirectory: $(Pipeline.Workspace)
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-  - script: git -c user.email=embeddedbot@microsoft.com -c user.name="Embedded Bot" tag -a $(TagName) -m "vcpkg-ce release $(TagName)" && git push origin $(TagName)
-    displayName: Push release tag
-    workingDirectory: $(Pipeline.Workspace)/vcpkg-ce
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-  - task: GitHubRelease@0
-    displayName: Publish to public repo
-    inputs:
-      gitHubConnection: embeddedbot
-      repositoryName: microsoft/vcpkg-ce
-      action: create
-      # We don't care what commit the releases are associated with in the
-      # issue-only repo, so just use the SHA of the initial commit. The task
-      # requires this parameter, but the actual release will end up using the
-      # SHA of the tag.
-      target: 70680994ce17917a99788b794a26347c35c805c9
-      tagSource: manual
-      tag: $(TagName)
-      assets: |
-        $(OutputDirectory)\ce
-        $(OutputDirectory)\ce.ps1
-        $(OutputDirectory)\ce.cmd
-        $(OutputDirectory)\ce.tgz
-        $(OutputDirectory)\signature.cat
-        $(OutputDirectory)\ce.tgz.asc
-        $(OutputDirectory)\ce.tgz.cat
-        $(OutputDirectory)\ce.asc
-      isPreRelease: false
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+            - bash: |
+                echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
+              displayName: Set tag commit hash
+              workingDirectory: '$(Build.SourcesDirectory)'
+            - task: GitHubRelease@0
+              displayName: Publish to public repo
+              condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+              inputs:
+                gitHubConnection: github/xilaraux
+                repositoryName: microsoft/vc-ue-extensions
+                action: create
+                target: $(SHA1)
+                tagSource: manual
+                tag: $(TagName)
+                title: $(TagName)
+                isDraft: false
+                isPreRelease: true
+                addChangeLog: false
+                assets: |
+                  $(OutputDirectory)\VisualStudioTools.zip
+                  $(OutputDirectory)\VisualStudioTools.zip.cat
+                  

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -2,16 +2,8 @@
 # Do not run BinSkim because we do not control producing the binaries. That process is owned by
 # Epic. We just provide source code. Since we do not control the build, BinSkim is not needed.
 
-trigger:
-  branches:
-    include:
-      - main
-  tags:
-    include:
-      - '*'
-
-pr:
-- main
+trigger: none
+pr: none
 
 resources:
   repositories:
@@ -63,23 +55,29 @@ extends:
                 solution: Scripts/SignDetached.proj
                 msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
             - bash: |
-                echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
-              displayName: Set tag commit hash
+                echo "ls -lR $(Agent.BuildDirectory)"
+              displayName: Show files
               workingDirectory: '$(Build.SourcesDirectory)'
-            - task: GitHubRelease@0
-              displayName: Publish to public repo
-              condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-              inputs:
-                gitHubConnection: github/xilaraux
-                repositoryName: microsoft/vc-ue-extensions
-                action: create
-                target: $(SHA1)
-                tagSource: manual
-                tag: $(TagName)
-                title: $(TagName)
-                isDraft: false
-                isPreRelease: true
-                addChangeLog: false
-                assets: |
-                   $(Agent.BuildDirectory)\out\VisualStudioTools.zip
-                   $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat
+            
+            # Commenting for now for polishin the pipeline
+            # - bash: |
+            #     echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
+            #   displayName: Set tag commit hash
+            #   workingDirectory: '$(Build.SourcesDirectory)'
+            # - task: GitHubRelease@0
+            #   displayName: Publish to public repo
+            #   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+            #   inputs:
+            #     gitHubConnection: github/xilaraux
+            #     repositoryName: microsoft/vc-ue-extensions
+            #     action: create
+            #     target: $(SHA1)
+            #     tagSource: manual
+            #     tag: $(TagName)
+            #     title: $(TagName)
+            #     isDraft: false
+            #     isPreRelease: true
+            #     addChangeLog: false
+            #     assets: |
+            #        $(Agent.BuildDirectory)\out\VisualStudioTools.zip
+            #        $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -2,6 +2,14 @@
 # Do not run BinSkim because we do not control producing the binaries. That process is owned by
 # Epic. We just provide source code. Since we do not control the build, BinSkim is not needed.
 
+variables:
+  # MicroBuild requires TeamName to be set.
+  TeamName: C++ Unreal Engine
+  # only test-sign for now
+  SignType: test
+  # TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
+
+# Manual trigger for now
 trigger: none
 pr: none
 
@@ -11,13 +19,6 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
-
-variables:
-  # MicroBuild requires TeamName to be set.
-  TeamName: C++ Unreal Engine
-  # only test-sign for now
-  SignType: test
-  TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -32,52 +33,65 @@ extends:
       jobs:
       - job: 'UnrealEngine_VisualStudioTools_Release'
         timeoutInMinutes: 1440
+        templateContext:
+          outputParentDirectory: $(Agent.BuildDirectory)/out/
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish signed plugin files'
+            targetPath: $(Agent.BuildDirectory)/out
+            artifactName: SignedPlugin
+            artifactType: container
+            sbomEnabled: false
         steps:
+          - powershell: |
+              Write-Host "##vso[task.setVariable variable=SHA1]$(git rev-parse HEAD)"
+            displayName: Save tag commit hash
+            workingDirectory: '$(Build.SourcesDirectory)'
           - task: MicroBuildSigningPlugin@4
             displayName: Install MicroBuild Signing
             inputs:
               signType: $(SignType)
               zipSources: true
-            - task: ArchiveFiles@2
-              displayName: Create zip from source folder
-              inputs:
-                rootFolderOrFile: $(Build.SourcesDirectory)
-                includeRootFolder: false
-                archiveType: zip
-                archiveFile: $(Agent.BuildDirectory)/out/VisualStudioTools.zip
-                replaceExistingArchive: true
-            - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
-              displayName: Create standalone zip catalog
-              workingDirectory: '$(Agent.BuildDirectory)\out'
-            - task: MSBuild@1
-              displayName: Sign catalogs
-              inputs:
-                solution: Scripts/SignDetached.proj
-                msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
-            - bash: |
-                echo "ls -lR $(Agent.BuildDirectory)"
-              displayName: Show files
-              workingDirectory: '$(Build.SourcesDirectory)'
-            
-            # Commenting for now for polishin the pipeline
-            # - bash: |
-            #     echo "##vso[task.setVariable variable=SHA1]$(git rev-parse $(TagName))"
-            #   displayName: Set tag commit hash
-            #   workingDirectory: '$(Build.SourcesDirectory)'
-            # - task: GitHubRelease@0
-            #   displayName: Publish to public repo
-            #   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
-            #   inputs:
-            #     gitHubConnection: github/xilaraux
-            #     repositoryName: microsoft/vc-ue-extensions
-            #     action: create
-            #     target: $(SHA1)
-            #     tagSource: manual
-            #     tag: $(TagName)
-            #     title: $(TagName)
-            #     isDraft: false
-            #     isPreRelease: true
-            #     addChangeLog: false
-            #     assets: |
-            #        $(Agent.BuildDirectory)\out\VisualStudioTools.zip
-            #        $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat
+          - task: PowerShell@2
+            displayName: "Create zip excluding .git folder"
+            inputs:
+              targetType: 'inline'
+              script: |
+                $destinationDirectory = "$(Agent.BuildDirectory)/out"
+                New-Item -Path $destinationDirectory -ItemType Directory
+                git archive -o "$destinationDirectory/VisualStudioTools.zip" $(SHA1)
+          - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
+            displayName: Create standalone catalog
+            workingDirectory: '$(Agent.BuildDirectory)\out'
+          - task: NuGetToolInstaller@1
+            inputs:
+              versionSpec: 5.7
+          - task: NuGetCommand@2
+            displayName: 'NuGet Restore MicroBuild Signing Extension'
+            inputs:
+              command: 'restore'
+              restoreSolution: 'Scripts/SignDetached.proj'
+              feedsToUse: 'config'
+              restoreDirectory: '$(Build.SourcesDirectory)\Scripts\packages'
+          - task: MSBuild@1
+            displayName: Sign catalogs
+            inputs:
+              solution: Scripts/SignDetached.proj
+              msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
+          # === Disabled for now in favor of uploading the artifacts to the pipeline ===
+          # - task: GitHubRelease@1
+          #   displayName: Pre-release to public repo
+          #   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+          #   inputs:
+          #     gitHubConnection: GitHub-VSCodeExtensions
+          #     repositoryName: microsoft/vc-ue-extensions
+          #     action: create
+          #     target: $(SHA1)
+          #     tagSource: gitTag
+          #     tag: $(TagName)
+          #     title: $(TagName)
+          #     isDraft: true
+          #     isPreRelease: true
+          #     assets: |
+          #         $(Agent.BuildDirectory)\out\VisualStudioTools.zip
+          #         $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -22,7 +22,7 @@ resources:
 
 variables:
   # MicroBuild requires TeamName to be set.
-  TeamName: C++ Cross Platform and Cloud
+  TeamName: C++ Unreal Engine
   # only test-sign for now
   SignType: test
   # This allows us to deploy to the repo.

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,0 +1,119 @@
+# IMPORTANT:
+# Do not run BinSkim because we do not control producing the binaries. That process is owned by
+# Epic. We just provide source code. Since we do not control the build, BinSkim is not needed.
+
+trigger:
+  branches:
+    include:
+      - main
+  tags:
+    include:
+      - '*'
+
+pr:
+- main
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+variables:
+  # MicroBuild requires TeamName to be set.
+  TeamName: C++ Cross Platform and Cloud
+  # only test-sign for now
+  SignType: test
+  # This allows us to deploy to the repo.
+  GIT_SSH_COMMAND: ssh -i "$(githubDeployKey.secureFilePath)"
+  TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: stage
+      jobs:
+      - job: 'UnrealEngine_VisualStudioTools_Compliance'
+        timeoutInMinutes: 1440
+        steps:
+          - task: MicroBuildSigningPlugin@4
+            displayName: Install MicroBuild Signing
+            inputs:
+              signType: $(SignType)
+              zipSources: true
+            - task: ArchiveFiles@2
+              displayName: Create zip from source folder
+              inputs:
+                rootFolderOrFile: $(Build.SourcesDirectory)
+                includeRootFolder: false
+                archiveType: zip
+                archiveFile: $(Agent.BuildDirectory)/out/VisualStudioTools.zip
+                replaceExistingArchive: true
+            - powershell: New-FileCatalog -Path .\VisualStudioTools.zip -CatalogFilePath .\VisualStudioTools.zip.cat -CatalogVersion 2.0
+              displayName: Create standalone zip catalog
+              workingDirectory: '$(Agent.BuildDirectory)\out'
+            - task: MSBuild@1
+              displayName: Sign catalogs
+              inputs:
+                solution: .scripts/signing/SignDetached.proj
+                msbuildArguments: /p:SignType=$(SignType) /p:BaseOutputDirectory=$(Agent.BuildDirectory)\out
+
+
+
+  # The following tasks publish to the issue-only public vcpkg-ce repo. We
+  # have a deploy key stored as a secret file in Azure Pipelines which is used
+  # to authenticate for pushing a tag and creating a release.
+  - task: DownloadSecureFile@1
+    displayName: Download deploy key
+    name: githubDeployKey
+    inputs:
+      secureFile: id_vcpkgce
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+  # GitHub has a large, regularly changing set of IP address, so ignore the
+  # hostname and allow anything with the right key.
+  # https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/about-githubs-ip-addresses
+  # This public key should have the well-known fingerprint documented below.
+  # SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+  # https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+  - script: mkdir %USERPROFILE%\.ssh && echo * ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==>>%USERPROFILE%\.ssh\known_hosts
+    displayName: Store GitHub public key
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+  - script: git clone git@github.com:microsoft/vcpkg-ce.git
+    displayName: Clone deployment repo
+    workingDirectory: $(Pipeline.Workspace)
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+  - script: git -c user.email=embeddedbot@microsoft.com -c user.name="Embedded Bot" tag -a $(TagName) -m "vcpkg-ce release $(TagName)" && git push origin $(TagName)
+    displayName: Push release tag
+    workingDirectory: $(Pipeline.Workspace)/vcpkg-ce
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))
+  - task: GitHubRelease@0
+    displayName: Publish to public repo
+    inputs:
+      gitHubConnection: embeddedbot
+      repositoryName: microsoft/vcpkg-ce
+      action: create
+      # We don't care what commit the releases are associated with in the
+      # issue-only repo, so just use the SHA of the initial commit. The task
+      # requires this parameter, but the actual release will end up using the
+      # SHA of the tag.
+      target: 70680994ce17917a99788b794a26347c35c805c9
+      tagSource: manual
+      tag: $(TagName)
+      assets: |
+        $(OutputDirectory)\ce
+        $(OutputDirectory)\ce.ps1
+        $(OutputDirectory)\ce.cmd
+        $(OutputDirectory)\ce.tgz
+        $(OutputDirectory)\signature.cat
+        $(OutputDirectory)\ce.tgz.asc
+        $(OutputDirectory)\ce.tgz.cat
+        $(OutputDirectory)\ce.asc
+      isPreRelease: false
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags'))

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -25,8 +25,6 @@ variables:
   TeamName: C++ Unreal Engine
   # only test-sign for now
   SignType: test
-  # This allows us to deploy to the repo.
-  GIT_SSH_COMMAND: ssh -i "$(githubDeployKey.secureFilePath)"
   TagName: $[replace(variables['Build.SourceBranch'], 'refs/tags/', '')]
 
 extends:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -83,6 +83,5 @@ extends:
                 isPreRelease: true
                 addChangeLog: false
                 assets: |
-                  $(OutputDirectory)\VisualStudioTools.zip
-                  $(OutputDirectory)\VisualStudioTools.zip.cat
-                  
+                   $(Agent.BuildDirectory)\out\VisualStudioTools.zip
+                   $(Agent.BuildDirectory)\out\VisualStudioTools.zip.cat


### PR DESCRIPTION
This PR adds release pipeline that will be triggered automatically once new tag is pushed. 
It will create `VisualStudioTools.zip` file with `catalog` file signature.

Downside of this approach for now will be that uploading of assets is manual to GitHub release. This is due to missing GitHub Connection - will update once we get a new one or approval to use existing.

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/170dc7b8-e9da-4e0e-813f-0c27d510e2ab">

Example of successful run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10139673&view=results
Note: it will be needed to manually create a release for the tag in https://github.com/microsoft/vc-ue-extensions/releases/new