### PR TITLE
chore: remove enable by default

### DIFF
--- a/VisualStudioTools.uplugin
+++ b/VisualStudioTools.uplugin
@@ -10,7 +10,6 @@
 	"DocsURL": "",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/362651520df94e4fa65492dbcba44ae2",
 	"SupportURL": "https://developercommunity.visualstudio.com/",
-	"EnabledByDefault": true,
 	"Installed": false,
 	"bExplicitlyLoaded": true,
 	"CanContainContent": false,


### PR DESCRIPTION
In this PR I remove `EnableByDefault` which presence affects installation of plugin as it is to Engine folder.
`as it is` meaning moving all files under `VisualInstallPlugin` in `Plugins` folder in Engine. If this flag is present - this fails and prevents plugin from being built by Engine. 