### PR TITLE
fix build failure on 5.5

### DIFF
--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -214,66 +214,69 @@ int32 UVSTestAdapterCommandlet::Main(const FString& Params)
 	}
 
 	// Default to all the test filters.
-	auto filter = EAutomationTestFlags::ProductFilter | EAutomationTestFlags::SmokeFilter | EAutomationTestFlags::PerfFilter | EAutomationTestFlags::EngineFilter;
+	uint32 filter = static_cast<uint32>(EAutomationTestFlags::ProductFilter) |
+					static_cast<uint32>(EAutomationTestFlags::SmokeFilter) |
+					static_cast<uint32>(EAutomationTestFlags::PerfFilter) |
+					static_cast<uint32>(EAutomationTestFlags::EngineFilter);
 	if (ParamVals.Contains(FiltersParam))
 	{
 		FString filters = ParamVals[FiltersParam];
 		if (filters.Contains("smoke"))
 		{
-			filter |= EAutomationTestFlags::SmokeFilter;
+			filter = static_cast<uint32>(EAutomationTestFlags::SmokeFilter);
 		}
 		else
 		{
-			filter &= ~EAutomationTestFlags::SmokeFilter;
+			filter = ~static_cast<uint32>(EAutomationTestFlags::SmokeFilter);
 		}
 
 		if (filters.Contains("engine"))
 		{
-			filter |= EAutomationTestFlags::EngineFilter;
+			filter = static_cast<uint32>(EAutomationTestFlags::EngineFilter);
 		}
 		else
 		{
-			filter &= ~EAutomationTestFlags::EngineFilter;
+			filter = ~static_cast<uint32>(EAutomationTestFlags::EngineFilter);
 		}
 
 		if (filters.Contains("product"))
 		{
-			filter |= EAutomationTestFlags::ProductFilter;
+			filter = static_cast<uint32>(EAutomationTestFlags::ProductFilter);
 		}
 		else
 		{
-			filter &= ~EAutomationTestFlags::ProductFilter;
+			filter = ~static_cast<uint32>(EAutomationTestFlags::ProductFilter);
 		}
 
 		if (filters.Contains("perf"))
 		{
-			filter |= EAutomationTestFlags::PerfFilter;
+			filter = static_cast<uint32>(EAutomationTestFlags::PerfFilter);
 		}
 		else
 		{
-			filter &= ~EAutomationTestFlags::PerfFilter;
+			filter = ~static_cast<uint32>(EAutomationTestFlags::PerfFilter);
 		}
 
 		if (filters.Contains("stress"))
 		{
-			filter |= EAutomationTestFlags::StressFilter;
+			filter = static_cast<uint32>(EAutomationTestFlags::StressFilter);
 		}
 		else
 		{
-			filter &= ~EAutomationTestFlags::StressFilter;
+			filter = ~static_cast<uint32>(EAutomationTestFlags::StressFilter);
 		}
 
 		if (filters.Contains("negative"))
 		{
-			filter |= EAutomationTestFlags::NegativeFilter;
+			filter = static_cast<uint32>(EAutomationTestFlags::NegativeFilter);
 		}
 		else
 		{
-			filter &= ~EAutomationTestFlags::NegativeFilter;
+			filter = ~static_cast<uint32>(EAutomationTestFlags::NegativeFilter);
 		}
 	}
 
-	FAutomationTestFramework::GetInstance().SetRequestedTestFilter(filter);
+	FAutomationTestFramework::GetInstance().SetRequestedTestFilter(static_cast<EAutomationTestFlags>(filter));
 	if (ParamVals.Contains(ListTestsParam))
 	{
 		return ListTests(ParamVals[ListTestsParam]);

--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -16,13 +16,13 @@ static constexpr auto RunTestsParam = TEXT("runtests");
 static constexpr auto TestResultsFileParam = TEXT("testresultfile");
 static constexpr auto HelpParam = TEXT("help");
 
-static void GetAllTests(TArray<FAutomationTestInfo>& OutTestList)
+static void GetAllTests(TArray<FAutomationTestInfo> &OutTestList)
 {
-	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
+	FAutomationTestFramework &Framework = FAutomationTestFramework::GetInstance();
 	Framework.GetValidTestNames(OutTestList);
 }
 
-static void ReadTestsFromFile(const FString& InFile, TArray<FAutomationTestInfo>& OutTestList)
+static void ReadTestsFromFile(const FString &InFile, TArray<FAutomationTestInfo> &OutTestList)
 {
 	TSet<FString> TestCommands;
 
@@ -55,7 +55,7 @@ static void ReadTestsFromFile(const FString& InFile, TArray<FAutomationTestInfo>
 	}
 }
 
-static int32 ListTests(const FString& TargetFile)
+static int32 ListTests(const FString &TargetFile)
 {
 	std::wofstream OutFile(*TargetFile);
 	if (!OutFile.good())
@@ -64,12 +64,12 @@ static int32 ListTests(const FString& TargetFile)
 		return 1;
 	}
 
-	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
+	FAutomationTestFramework &Framework = FAutomationTestFramework::GetInstance();
 
 	TArray<FAutomationTestInfo> TestInfos;
 	GetAllTests(TestInfos);
 
-	for (const auto& TestInfo : TestInfos)
+	for (const auto &TestInfo : TestInfos)
 	{
 		const FString TestCommand = TestInfo.GetTestName();
 		const FString DisplayName = TestInfo.GetDisplayName();
@@ -85,7 +85,7 @@ static int32 ListTests(const FString& TargetFile)
 	return 0;
 }
 
-static int32 RunTests(const FString& TestListFile, const FString& ResultsFile)
+static int32 RunTests(const FString &TestListFile, const FString &ResultsFile)
 {
 	std::wofstream OutFile(*ResultsFile);
 	if (!OutFile.good())
@@ -106,9 +106,9 @@ static int32 RunTests(const FString& TestListFile, const FString& ResultsFile)
 
 	bool AllSuccessful = true;
 
-	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
+	FAutomationTestFramework &Framework = FAutomationTestFramework::GetInstance();
 
-	for (const FAutomationTestInfo& TestInfo : TestInfos)
+	for (const FAutomationTestInfo &TestInfo : TestInfos)
 	{
 		const FString TestCommand = TestInfo.GetTestName();
 		const FString DisplayName = TestInfo.GetDisplayName();
@@ -149,7 +149,7 @@ static int32 RunTests(const FString& TestListFile, const FString& ResultsFile)
 
 		if (!CurrentTestSuccessful)
 		{
-			for (const auto& Entry : ExecutionInfo.GetEntries())
+			for (const auto &Entry : ExecutionInfo.GetEntries())
 			{
 				if (Entry.Event.Type == EAutomationEventType::Error)
 				{
@@ -199,7 +199,7 @@ void UVSTestAdapterCommandlet::PrintHelp() const
 	}
 }
 
-int32 UVSTestAdapterCommandlet::Main(const FString& Params)
+int32 UVSTestAdapterCommandlet::Main(const FString &Params)
 {
 	TArray<FString> Tokens;
 	TArray<FString> Switches;

--- a/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
+++ b/Source/VisualStudioTools/Private/VSTestAdapterCommandlet.cpp
@@ -16,13 +16,13 @@ static constexpr auto RunTestsParam = TEXT("runtests");
 static constexpr auto TestResultsFileParam = TEXT("testresultfile");
 static constexpr auto HelpParam = TEXT("help");
 
-static void GetAllTests(TArray<FAutomationTestInfo> &OutTestList)
+static void GetAllTests(TArray<FAutomationTestInfo>& OutTestList)
 {
-	FAutomationTestFramework &Framework = FAutomationTestFramework::GetInstance();
+	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
 	Framework.GetValidTestNames(OutTestList);
 }
 
-static void ReadTestsFromFile(const FString &InFile, TArray<FAutomationTestInfo> &OutTestList)
+static void ReadTestsFromFile(const FString& InFile, TArray<FAutomationTestInfo>& OutTestList)
 {
 	TSet<FString> TestCommands;
 
@@ -55,7 +55,7 @@ static void ReadTestsFromFile(const FString &InFile, TArray<FAutomationTestInfo>
 	}
 }
 
-static int32 ListTests(const FString &TargetFile)
+static int32 ListTests(const FString& TargetFile)
 {
 	std::wofstream OutFile(*TargetFile);
 	if (!OutFile.good())
@@ -64,12 +64,12 @@ static int32 ListTests(const FString &TargetFile)
 		return 1;
 	}
 
-	FAutomationTestFramework &Framework = FAutomationTestFramework::GetInstance();
+	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
 
 	TArray<FAutomationTestInfo> TestInfos;
 	GetAllTests(TestInfos);
 
-	for (const auto &TestInfo : TestInfos)
+	for (const auto& TestInfo : TestInfos)
 	{
 		const FString TestCommand = TestInfo.GetTestName();
 		const FString DisplayName = TestInfo.GetDisplayName();
@@ -85,7 +85,7 @@ static int32 ListTests(const FString &TargetFile)
 	return 0;
 }
 
-static int32 RunTests(const FString &TestListFile, const FString &ResultsFile)
+static int32 RunTests(const FString& TestListFile, const FString& ResultsFile)
 {
 	std::wofstream OutFile(*ResultsFile);
 	if (!OutFile.good())
@@ -106,9 +106,9 @@ static int32 RunTests(const FString &TestListFile, const FString &ResultsFile)
 
 	bool AllSuccessful = true;
 
-	FAutomationTestFramework &Framework = FAutomationTestFramework::GetInstance();
+	FAutomationTestFramework& Framework = FAutomationTestFramework::GetInstance();
 
-	for (const FAutomationTestInfo &TestInfo : TestInfos)
+	for (const FAutomationTestInfo& TestInfo : TestInfos)
 	{
 		const FString TestCommand = TestInfo.GetTestName();
 		const FString DisplayName = TestInfo.GetDisplayName();
@@ -149,7 +149,7 @@ static int32 RunTests(const FString &TestListFile, const FString &ResultsFile)
 
 		if (!CurrentTestSuccessful)
 		{
-			for (const auto &Entry : ExecutionInfo.GetEntries())
+			for (const auto& Entry : ExecutionInfo.GetEntries())
 			{
 				if (Entry.Event.Type == EAutomationEventType::Error)
 				{
@@ -199,7 +199,7 @@ void UVSTestAdapterCommandlet::PrintHelp() const
 	}
 }
 
-int32 UVSTestAdapterCommandlet::Main(const FString &Params)
+int32 UVSTestAdapterCommandlet::Main(const FString& Params)
 {
 	TArray<FString> Tokens;
 	TArray<FString> Switches;
@@ -215,9 +215,9 @@ int32 UVSTestAdapterCommandlet::Main(const FString &Params)
 
 	// Default to all the test filters.
 	uint32 filter = static_cast<uint32>(EAutomationTestFlags::ProductFilter) |
-					static_cast<uint32>(EAutomationTestFlags::SmokeFilter) |
-					static_cast<uint32>(EAutomationTestFlags::PerfFilter) |
-					static_cast<uint32>(EAutomationTestFlags::EngineFilter);
+		static_cast<uint32>(EAutomationTestFlags::SmokeFilter) |
+		static_cast<uint32>(EAutomationTestFlags::PerfFilter) |
+		static_cast<uint32>(EAutomationTestFlags::EngineFilter);
 	if (ParamVals.Contains(FiltersParam))
 	{
 		FString filters = ParamVals[FiltersParam];


### PR DESCRIPTION
noticed a build failure on unreal 5.5 when it attempts to convert uint32. so i thought i would be nice and fix it!

i tested it myself and it builds successfully

(i edited lines 216-277 and line 279. github doesn't seem to be displaying my changes properly)

Steps to reproduce:

- download visual studio tools 2.5 for unreal 5.4 from GitHub releases and add them to the plugins folder for your unreal 5.5 project

- attempt to compile your project from visual studio

- build fails and check error log. Most errors are about converting uint32