### PR TITLE
Add version info include

### DIFF
--- a/Source/VisualStudioBlueprintDebuggerHelper/Private/VisualStudioBlueprintDebuggerHelperModule.cpp
+++ b/Source/VisualStudioBlueprintDebuggerHelper/Private/VisualStudioBlueprintDebuggerHelperModule.cpp
@@ -11,6 +11,7 @@
 #include <UObject/Class.h>
 #include <Engine/BlueprintGeneratedClass.h>
 #include <Engine/Blueprint.h>
+#include <Runtime/Launch/Resources/Version.h>
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 4
 #include <Blueprint/BlueprintExceptionInfo.h>
 #endif


### PR DESCRIPTION
Add include for `ENGINE_MAJOR_VERSION` and `ENGINE_MINOR_VERSION`. Fixes non-unity build of module.