### PR TITLE
chore: update patch

### DIFF
--- a/azure-pipelines/Support-extra-UBT-args-in-UAT.BuildPlugin.patch
+++ b/azure-pipelines/Support-extra-UBT-args-in-UAT.BuildPlugin.patch
@@ -1,19 +1,20 @@
-From d2c553415dc34af67b744e6a4faeb8cc74472be4 Mon Sep 17 00:00:00 2001
-From: Henrique Fernandes Baggio <hebaggio@microsoft.com>
-Date: Mon, 29 Jan 2024 10:38:05 -0800
+From f7238064c8680f6392793eb664ee2c773daff594 Mon Sep 17 00:00:00 2001
+From: Oleksandr Kozlov <okozlov@microsoft.com>
+Date: Tue, 1 Apr 2025 15:22:14 +0200
 Subject: [PATCH] Support extra UBT args in UAT.BuildPlugin
 
 Forwarding extra parameters to UBT to allow customizing the build of a plugin.
 Example: runuat.bat buildpluing -plugin=... -ubtargs="-LinkerArguments=\"/profile\""
+
 ---
  .../Scripts/BuildPluginCommand.Automation.cs        | 13 +++++++++++++
  1 file changed, 13 insertions(+)
 
 diff --git a/Engine/Source/Programs/AutomationTool/Scripts/BuildPluginCommand.Automation.cs b/Engine/Source/Programs/AutomationTool/Scripts/BuildPluginCommand.Automation.cs
-index dbae467f82f6..e8416b607c07 100644
+index 5a43dc0c4..aaf3f192f 100644
 --- a/Engine/Source/Programs/AutomationTool/Scripts/BuildPluginCommand.Automation.cs
 +++ b/Engine/Source/Programs/AutomationTool/Scripts/BuildPluginCommand.Automation.cs
-@@ -63,6 +63,9 @@ public sealed class BuildPlugin : BuildCommand
+@@ -64,6 +64,9 @@ public sealed class BuildPlugin : BuildCommand
  		// Option for verifying that all include directive s
  		bool bStrictIncludes = ParseParam("StrictIncludes");
  
@@ -22,8 +23,8 @@ index dbae467f82f6..e8416b607c07 100644
 +
  		// Make sure the packaging directory is valid
  		DirectoryReference PackageDir = new DirectoryReference(PackageParam);
- 		if (PluginFile.IsUnderDirectory(PackageDir))
-@@ -117,6 +120,16 @@ public sealed class BuildPlugin : BuildCommand
+ 		
+@@ -126,6 +129,16 @@ public sealed class BuildPlugin : BuildCommand
  			AdditionalArgs.Append(" -NoPCH -NoSharedPCH -DisableUnity");
  		}
  
@@ -41,5 +42,5 @@ index dbae467f82f6..e8416b607c07 100644
  		foreach (UnrealTargetPlatform Platform in UnrealTargetPlatform.GetValidPlatforms())
  		{
 -- 
-2.43.0.windows.1
+2.49.0.windows.1
 


### PR DESCRIPTION
Compliance pipeline fails due to patch being outdated and not being able to be applied to `release` branch of UE.
This PR updates the patch.