### PR TITLE
Disable VisualStudioBlueprintDebuggerHelper loading by default

### DIFF
--- a/VisualStudioTools.uplugin
+++ b/VisualStudioTools.uplugin
@@ -29,7 +29,7 @@
 		{
 			"Name": "VisualStudioBlueprintDebuggerHelper",
 			"Type": "Editor",
-			"LoadingPhase": "Default",
+			"LoadingPhase": "None",
 			"PlatformAllowList": [
 				"Win64"
 			]


### PR DESCRIPTION
This will disable the automatically loading for the module, requiring users to either load it on code or manually change the uplugin definition.