### PR TITLE
Implement loop node handling in VisualStudioBlueprintDebuggerHelper

### DIFF
--- a/Source/VisualStudioBlueprintDebuggerHelper/Private/VisualStudioBlueprintDebuggerHelperModule.cpp
+++ b/Source/VisualStudioBlueprintDebuggerHelper/Private/VisualStudioBlueprintDebuggerHelperModule.cpp
@@ -19,6 +19,7 @@
 #include <HAL/Platform.h>
 #include <EdGraph/EdGraphNode.h>
 #include <EdGraph/EdGraphPin.h>
+#include <K2Node_MacroInstance.h>
 #include <Templates/SharedPointer.h>
 #include <Templates/Tuple.h>
 #include <CoreGlobals.h>
@@ -54,9 +55,16 @@ struct FVSNodeData
 	const UEdGraphNode* Node;
 };
 
+struct FVSNodesRuntimeLoopInformation
+{
+	const UEdGraphNode* LoopNode;
+	const UEdGraphNode* LoopBodyNode;
+};
+
 struct FVSNodesRuntimeInformation
 {
 	TArray<TSharedPtr<FVSNodeData>> Nodes;
+	TArray<FVSNodesRuntimeLoopInformation> LoopInfos;
 };
 
 struct FVSBlueprintRuntimeInformation
@@ -205,6 +213,63 @@ void FVisualStudioBlueprintDebuggerHelper::OnScriptException(
 	else
 	{
 		NodesRuntimeInformation = ExistingNodesRuntimeInformationTuple->Value;
+	}
+
+	// Loop nodes are specialized 
+	// Loop nodes are pseudo-loops internally with Sequence nodes 
+	// VisualStudioBlueprintDebuggerHelper stores the paths followed by Blueprint nodes 
+	// Number of Loops * The number of paths is increased when the number of loops is huge. 
+	// Attempts to reduce the processing load by reducing the number of paths saved in a loop by deleting the paths executed in the previously passed LoopBody every time a node connected to the LoopBody of the Loop is passed. An attempt to reduce the processing load
+	if (const UK2Node_MacroInstance* MacroInstance = Cast<UK2Node_MacroInstance>(NodeStoppedAt))
+	{
+		static const FName StandardMacrosPackageName = TEXT("/Engine/EditorBlueprintResources/StandardMacros");
+		const UBlueprint* SourceBlueprint = MacroInstance->GetSourceBlueprint();
+		if (SourceBlueprint->GetPackage()->GetFName() == StandardMacrosPackageName)
+		{
+			const FName MacroGraphName = MacroInstance->GetMacroGraph()->GetFName();
+			if (MacroGraphName == TEXT("ForLoop") ||
+				MacroGraphName == TEXT("ForLoopWithBreak") ||
+				MacroGraphName == TEXT("ForEachLoop") ||
+				MacroGraphName == TEXT("ForEachLoopWithBreak") ||
+				MacroGraphName == TEXT("ReverseForEachLoop") ||
+				MacroGraphName == TEXT("WhileLoop"))
+			{
+				const UEdGraphPin* LoopBodyPin = MacroInstance->FindPin(TEXT("LoopBody"));
+				if (LoopBodyPin && !LoopBodyPin->LinkedTo.IsEmpty())
+				{
+					const UEdGraphPin* LinkedToPin = LoopBodyPin->LinkedTo[0];
+					if (LinkedToPin)
+					{
+						const UEdGraphNode* LoopBodyNode = LinkedToPin->GetOwningNode();
+						if (LoopBodyNode)
+						{
+							FVSNodesRuntimeLoopInformation LoopByNodeInfo;
+							LoopByNodeInfo.LoopNode = MacroInstance;
+							LoopByNodeInfo.LoopBodyNode = LoopBodyNode;
+							NodesRuntimeInformation->LoopInfos.Add(LoopByNodeInfo);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if (!NodesRuntimeInformation->LoopInfos.IsEmpty())
+	{
+		const FVSNodesRuntimeLoopInformation& LastLoopInfomation = NodesRuntimeInformation->LoopInfos[NodesRuntimeInformation->LoopInfos.Num() - 1];
+		if (LastLoopInfomation.LoopBodyNode == NodeStoppedAt)
+		{
+			for (int32 NodeIndex = NodesRuntimeInformation->Nodes.Num() - 1; NodeIndex >= 0; --NodeIndex)
+			{
+				TSharedPtr<FVSNodeData>& Node = NodesRuntimeInformation->Nodes[NodeIndex];
+				if (Node->Node == LastLoopInfomation.LoopNode)
+				{
+					break;
+				}
+
+				NodesRuntimeInformation->Nodes.RemoveAt(NodeIndex);
+			}
+		}
 	}
 
 	TSharedPtr<FVSNodeData> CurrentNodeData;


### PR DESCRIPTION

VisualStudioBlueprintDebuggerHelper is a plugin that can hold the execution path of a Blueprint and display it in a debugger.
When using Loop-type nodes, the paths displayed are huge and difficult to use for debugging.
The routes are stored for the number of loops * the number of nodes after the LoopBody.

<img width="1044" height="281" alt="image" src="https://github.com/user-attachments/assets/fdd8a7fa-52e8-4840-b9d2-9163519f3d06" />

When you run the above Blueprint, stop the debugger at PrintString and look at the Blueprint debugger, you will see the following.
Debugging is difficult because a huge number of Node information is displayed.

<img width="954" height="585" alt="スクリーンショット 2025-07-20 031808" src="https://github.com/user-attachments/assets/66e22073-de90-4713-8119-c876ea9d0798" />

<img width="1688" height="305" alt="image" src="https://github.com/user-attachments/assets/c3b41238-603a-45f0-a940-a9dd68d688a0" />

Specializations have been implemented for Loop nodes described in "StandardMacros".

> ForLoop, ForLoopWithBreak, ForEachLoop, ForEachLoopWithBreak, ReverseForEachLoop, WhileLoop

Simplification is done by deleting the last Node passed each time the LoopBody of a Loop-type node is passed.
This allows for minimal display.