### PR TITLE
build: migrate UnsafeTypeCastWarningLevel to CppCompileWarningSettings (UE 5.6)

### DIFF
--- a/Source/VisualStudioTools/VisualStudioTools.Build.cs
+++ b/Source/VisualStudioTools/VisualStudioTools.Build.cs
@@ -19,12 +19,13 @@ public class VisualStudioTools : ModuleRules
             // proper local variable inspection and less inlined stack frames
             OptimizeCode = CodeOptimization.Never;
 
-            // Enable more restrict warnings during compilation in UE5.
+            // Enable more restricted warnings during compilation in UE5.
             // Required by tasks in the compliance pipeline.
-            if (Target.Version.MajorVersion >= 5)
-            {
+            #if UE_5_6_OR_LATER
+                CppCompileWarningSettings.UnsafeTypeCastWarningLevel = WarningLevel.Error;
+            #elif UE_5_0_OR_LATER
                 UnsafeTypeCastWarningLevel = WarningLevel.Error;
-            }
+            #endif
         }
         else
         {


### PR DESCRIPTION
## Summary
Unreal Engine 5.6 deprecated `ModuleRules.UnsafeTypeCastWarningLevel`.  
This PR migrates it to the new `ModuleRules.CppCompileWarningSettings.UnsafeTypeCastWarningLevel` API.

## Motivation
Building the plugin on UE 5.6+ currently emits CS0618 deprecation warnings.  
This change removes those warnings while keeping behavior identical.

## Implementation
- Added version-guarded macros:
  - `UE_5_6_OR_LATER` → use `CppCompileWarningSettings.UnsafeTypeCastWarningLevel`
  - `UE_5_0_OR_LATER` → use legacy `UnsafeTypeCastWarningLevel`
- Preserves the same strictness (`WarningLevel.Error`).
- No runtime impact; Build.cs only.

## Build & Validation
Built successfully using the documented workflow:

```powershell
msbuild -p:UnrealEngine=5.6 -p:OutputPath=C:\_out\VSTUE_Build
````
✔️ Build succeeded with 0 errors.
ℹ️ Warnings observed:
* Visual Studio 2022 compiler not preferred (informational).
* C4996 deprecations in `VisualStudioToolsCommandlet.cpp` related to `UClass::ClassDefaultObject`
  (unrelated to this PR; can be addressed in a separate change by using `GetDefault<>`/`GetMutableDefault<>`).

