### PR TITLE
Onboard pipelines to CFS network isolation (SFI-ES4.2.4)

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Restore packages from the Central Feed Services (CFS) feed instead of the public
+  nuget.org so the release pipeline stays compliant with network isolation
+  (Permissive,CFSClean,CFSClean2,CFSClean3). <clear /> drops any inherited public
+  sources so only the CFS feed is used.
+
+  OSS contributors building locally can delete this file to restore from nuget.org.
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="cpp_PublicPackages" value="https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -39,6 +39,8 @@ extends:
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     stages:
     - stage: stage
       jobs:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -48,6 +48,8 @@ extends:
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     stages:
     - stage: stage
       jobs:
@@ -92,6 +94,7 @@ extends:
               command: 'restore'
               restoreSolution: 'Scripts/SignDetached.proj'
               feedsToUse: 'config'
+              nugetConfigPath: '$(Build.SourcesDirectory)/NuGet.config'
               restoreDirectory: '$(Build.SourcesDirectory)\Scripts\packages'
           - task: MSBuild@1
             displayName: Sign catalogs


### PR DESCRIPTION
Add networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3 to the compliance and release 1ES pipelines so they no longer reach public package feeds, per the Central Feed Services (CFS) requirement.

The release pipeline restores Microsoft.VisualStudioEng.MicroBuild.Core via NuGetCommand@2 with feedsToUse: config, which previously fell through to the public nuget.org and would be blocked by CFSClean. Add a NuGet.config that clears inherited sources and points the restore at the CFS NuGet feed (azure-public/cpp_PublicPackages), and reference it explicitly via nugetConfigPath. This mirrors the .npmrc registry redirect used in the Node-based repos; NuGet has no always-auth equivalent since the CFS public feed is accessed anonymously.

The compliance pipeline has no package restore - its git clone of UnrealEngine and Setup.bat downloads go through the Permissive policy (not package feeds) - so it only needs the policy added.