### PR TITLE
Redirect NuGet restore to CFS feed for network isolation compliance

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Restore packages from the Central Feed Services (CFS) feed instead of the public
-  nuget.org so the release pipeline stays compliant with network isolation
+  nuget.org so the pipelines stay compliant with network isolation
   (Permissive,CFSClean,CFSClean2,CFSClean3). <clear /> drops any inherited public
   sources so only the CFS feed is used.
+
+  This file is consumed in two ways:
+    * release.yml restores the MicroBuild signing extension with nugetConfigPath set here.
+    * compliance.yml builds the plugin, which compiles Unreal Engine's C# tooling in the
+      cloned UE tree (a sibling of this repo). That step sets the RestoreConfigFile env var
+      to this file so those restores also use the CFS feed instead of api.nuget.org.
 
   OSS contributors building locally can delete this file to restore from nuget.org.
 -->

--- a/azure-pipelines/compliance.yml
+++ b/azure-pipelines/compliance.yml
@@ -72,6 +72,15 @@ extends:
         - task: MSBuild@1
           displayName: 'Build Plugin'
           timeoutInMinutes: 300
+          env:
+            # Building the plugin compiles Unreal Engine's own C# tooling (UnrealBuildTool,
+            # AutomationTool, EpicGames.*), which restores NuGet packages. Those projects live in
+            # the cloned UE tree (a sibling of this repo), so NuGet's directory walk never finds the
+            # repo-root NuGet.config and falls back to api.nuget.org, which is blocked under network
+            # isolation (Permissive,CFSClean,CFSClean2,CFSClean3) -> NU1301. Setting RestoreConfigFile
+            # forces every restore in this step's process tree (msbuild -> build.proj -> RunUAT ->
+            # dotnet build) to use the repo's CFS-only NuGet.config instead.
+            RestoreConfigFile: '$(Build.SourcesDirectory)/NuGet.config'
           inputs:
             solution: '$(Build.SourcesDirectory)/build.proj'
             msbuildArguments: '/p:UnrealEngine=$(Agent.BuildDirectory)\ue /p:OutputPath=$(Build.ArtifactStagingDirectory)\drop /p:VulkanReadyBinaries=true'


### PR DESCRIPTION
The compliance pipeline builds the plugin via RunUAT.bat BuildPlugin, which first compiles Unreal Engine's own C# tooling (UnrealBuildTool, AutomationTool, EpicGames.*) in the cloned UE tree at $(Agent.BuildDirectory)\ue. That tree is a sibling of the repo checkout, so NuGet's directory-walk config discovery never finds the repo-root NuGet.config and the restore falls back to api.nuget.org, which is blocked under network isolation (Permissive,CFSClean,CFSClean2,CFSClean3), failing with NU1301.

Set RestoreConfigFile to the repo's CFS-only NuGet.config as an env var on the Build Plugin step so every restore in the msbuild -> build.proj -> RunUAT -> dotnet build process tree uses the CFS feed instead.